### PR TITLE
Add faction specific data, initial work

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,7 +40,7 @@ export function App() {
     <Container fluid='lg'>
       {roster === null ? <Homepage onUpload={handleUpload} /> : <></>}
       {roster && isRosterKT18(roster) ? <RosterView2018 name={roster.name} models={roster.models} onClose={handleClose} forceRules={roster.forceRules} onSelectionChanged={handleSelectionChanged} /> : <></>}
-      {roster && isRosterKT21(roster) ? <RosterView2021 name={roster.name} operatives={roster.operatives} psychicPowers={roster.psychicPowers} onClose={handleClose} /> : <></>}
+      {roster && isRosterKT21(roster) ? <RosterView2021 name={roster.name} operatives={roster.operatives} psychicPowers={roster.psychicPowers} faction={roster.faction} onClose={handleClose} /> : <></>}
     </Container>
   )
 }

--- a/src/components/KillTeam2021/PloysColumn.tsx
+++ b/src/components/KillTeam2021/PloysColumn.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Ploy } from '../../types/KillTeam2021';
+import { Card, Col, Table } from 'react-bootstrap';
+import { HighlightedText } from './HighlightedText'
+
+type Props = {
+  ploys: Ploy[]
+};
+
+export function PloysColumn(props: Props) {
+  return <Col>
+    {props.ploys.map((x: Ploy) => (
+        <Card border="info" bg="light">
+          <Card.Header style={{ background: "#17a2b8", color: "white", display: "flex", justifyContent: "space-between" }} as="h4">
+            <span>{x.name}</span>
+            <span>{x.cost}CP</span>
+          </Card.Header>
+          <Card.Body>
+            <p>
+              <HighlightedText>{x.description}</HighlightedText>
+            </p>
+            {x.weapon
+              ? <Table striped bordered size="sm">
+                <thead>
+                  <tr>
+                    <th>A</th>
+                    <th>WS</th>
+                    <th>D</th>
+                    <th>SR</th>
+                    <th>!</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>{x.weapon.attacks}</td>
+                    <td>{x.weapon.hit}+</td>
+                    <td>{x.weapon.damage}/{x.weapon.criticalDamage}</td>
+                    <td><HighlightedText>{x.weapon.specialRules}</HighlightedText></td>
+                    <td><HighlightedText>{x.weapon.criticalRules}</HighlightedText></td>
+                  </tr>
+                </tbody>
+              </Table>
+              : <></>
+            }
+          </Card.Body>
+        </Card>
+    ))}
+  </Col>
+}

--- a/src/components/KillTeam2021/Roster.tsx
+++ b/src/components/KillTeam2021/Roster.tsx
@@ -5,11 +5,15 @@ import { Operative, Datacard, PsychicPower } from '../../types/KillTeam2021';
 import { Datasheet } from './Datasheet';
 import { RuleList } from './RuleList';
 import { PowerList } from './PowerList';
+import { PloysColumn } from './PloysColumn';
+import { TacOpsList } from './TacOpsList';
 import hash from 'node-object-hash'
 import _ from 'lodash'
+import getFactionSpecificData from './data'
 
 type Props = {
   name: string,
+  faction: string,
   operatives: Operative[],
   psychicPowers: PsychicPower[],
   onClose: (event: MouseEvent<HTMLButtonElement>) => void,
@@ -33,6 +37,8 @@ export function Roster(props: Props) {
     display: 'flex',
   };
   const datacards = groupByDatacard(props.operatives)
+  const factionSpecificData = getFactionSpecificData(props.faction)
+
   return <>
     <h1 style={headingStyle}>
       <Col>
@@ -57,5 +63,30 @@ export function Roster(props: Props) {
         <PowerList powers={props.psychicPowers}/>
       </Card.Body>
     </Card>}
+
+    {factionSpecificData &&
+      <div>
+        <div style={{display: "flex", justifyContent: "space-between", flexDirection: "row"}}>
+          <Card style={{width: "100%", marginRight: "5px"}}>
+            <Card.Header style={{...headingStyle}} as="h2">Strategic Ploys</Card.Header>
+            <Card.Body>
+              <PloysColumn ploys={factionSpecificData.strategicPloys} />
+            </Card.Body>
+          </Card>
+          <Card style={{width: "100%", marginLeft: "5px"}}>
+            <Card.Header style={{...headingStyle}} as="h2">Tactical Ploys</Card.Header>
+            <Card.Body>
+              <PloysColumn ploys={factionSpecificData.tacticalPloys} />
+            </Card.Body>
+          </Card>
+        </div>
+        <Card>
+          <Card.Header style={{...headingStyle}} as="h2">Tac Ops</Card.Header>
+          <Card.Body>
+            <TacOpsList tacOps={factionSpecificData.tacOps} />
+          </Card.Body>
+        </Card>
+      </div>
+    }
   </>
 }

--- a/src/components/KillTeam2021/TacOpsList.tsx
+++ b/src/components/KillTeam2021/TacOpsList.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { TacOp } from '../../types/KillTeam2021';
+import { Card, Row, Col } from 'react-bootstrap';
+import { HighlightedText } from './HighlightedText'
+
+type Props = {
+  tacOps: TacOp[]
+};
+
+export function TacOpsList(props: Props) {
+  return <Row xs={1} sm={2} md={3} className="g-4">
+    {props.tacOps.map((x: TacOp) => (
+      <Col>
+        <Card border="info" bg="light">
+          <Card.Header style={{ background: "#17a2b8", color: "white", display: "flex", justifyContent: "space-between" }} as="h4">
+            <span>Tac Op {x.id}</span>
+            <span>{x.name}</span>
+          </Card.Header>
+          <Card.Body>
+            <p>
+              {x.revealTime}
+            </p>
+            <p>
+              <ul>
+                {x.description.map(line => <li><HighlightedText>{line}</HighlightedText></li>)}
+              </ul>
+            </p>
+            {
+              x.action &&
+              <>
+                <p>
+                  Friendly operatives an perform the following mission action:
+                </p>
+                <p>
+                  <Card border="primary" bg="light">
+                    <Card.Header style={{ background: "#FF6F2D", color: "white", display: "flex", justifyContent: "space-between"}} as="h4">
+                      <span>{x.action.name}</span>
+                      <span>{x.action.cost}AP</span>
+                    </Card.Header>
+                    <Card.Body>
+                      <HighlightedText>{x.action.description}</HighlightedText>
+                    </Card.Body>
+                  </Card>
+                </p>
+              </>
+            }
+          </Card.Body>
+        </Card>
+      </Col>
+    ))}
+  </Row>
+}

--- a/src/components/KillTeam2021/data/index.ts
+++ b/src/components/KillTeam2021/data/index.ts
@@ -1,0 +1,15 @@
+import veteranGuardsmen from "./veteranGuardsmen"
+import kommando from "./kommando"
+
+const getFactionSpecificData = (factionName: string) => {
+  switch (factionName) {
+    case "Veteran Guardsmen":
+      return veteranGuardsmen;
+    case "Kommando":
+      return kommando;
+    default:
+      return null;
+  }
+}
+
+export default getFactionSpecificData

--- a/src/components/KillTeam2021/data/kommando.ts
+++ b/src/components/KillTeam2021/data/kommando.ts
@@ -1,0 +1,79 @@
+import { Ploy, TacOp } from '../../../types/KillTeam2021';
+
+const strategicPloys: Ploy[] = [
+  {
+    name: 'Sssshhhh!',
+    cost: 1,
+    description: `Friendly KOMMANDO💀 operatives that are not within Line of Sight of enemy operatives, or have a Conceal order and are more than ⬟ from enemy operatives,
+                  can immediately perform a free Dash action. You can only use this strategic ploy once.`
+  }, {
+    name: 'Dakka! Dakka! Dakka!',
+    cost: 1,
+    description: `Until the end of the Turning Point, each time a friendly KOMMANDO💀 operative makes a shooting attack, in the Roll Attack Dice step of that shooting attack,
+                  if you retain any critical hits, you can select one of your failed hits to be retained as a successfull normal hit.`
+  }, {
+    name: 'Waaagh!',
+    cost: 1,
+    description: `Until the end of the Turning Point, each time a friendly KOMMANDO💀 operative fights in combat, in a Roll Attack Dice step of that combat,
+                  when you would retain two or more normal hits, you can select one of those hits to be retained as a critical hit instead.`
+  }, {
+    name: 'Skulk about',
+    cost: 1,
+    description: `Until the end of the Turning Point, each time a shooting attack is made against a friendly KOMMANDO💀 operative, before rolling defence dice for that shooting attack,
+                  if it has a Conceal order, you can retain one as a successfull normal save without rolling it.`
+  }
+]
+
+const tacticalPloys: Ploy[] = [
+  {
+    name: 'Just a scratch',
+    cost: 1,
+    description: `Use this tactical Ploy in the Resolve Successfull Hits step of a shooting attack or combat, when damage would beinflicked on a friendly KOMMANDO💀 operative,
+                  (excluding KOMMANDO GROT operatives), from an attack dice. Ignore the damage inflicted from that attack dice.`
+  }, {
+    name: 'Krump \'em!',
+    cost: 1,
+    description: 'Use this Tactical Ploy at the end of a Firefights phase. Select one friendly KOMMANDO💀 operative. It can perform a free Fight action.'
+  }, {
+    name: 'Sneaky git',
+    cost: 1,
+    description: `Use this Tactical Ploy in the Set Up Operatives step of the mission sequence. Select one friendly KOMMANDO💀 operative (excluding BOMB SQUIG operatives).
+                  That operative can be set up with a Conceal order anywhere on the battlefield that is within ▲ of Heavy terrain and more than ⬟ from enemy operatives and the enemy drop zone.`
+  }
+]
+
+const tacOps: TacOp[] = [
+  {
+    id: 1,
+    name: 'Blow it up!',
+    revealTime: `You can reveal this Tac Op in the Target Reveal step of the first Turning Point.
+                 Your opponent selects one terrain feature that includes any parts with the Heavy trait to be their bulwark.`,
+    description: ['If a friendly operative performs the \'Blow it up!\' action, you score 2VPs'],
+    action: {
+      name: 'Blow it up!',
+      cost: 2,
+      description: `An operative can perform this action while within ▲ of your opponent's bulwark. An operative cannot perform this action while within ⬤ of enemy operatives.
+                    Other than a Dash action, an operative cannot perform any other action during an activation in which it would perform this action.`
+    }
+  }, {
+    id: 2,
+    name: 'Shokk taktiks',
+    revealTime: 'Reveal this TacOp at the end of the first Turning Point',
+    description: [
+      'If any enemy operatives were incapacitated during the first Turning Point, you score 1 VP.',
+      'At the end of the second Turning Point, if friendly operatives control more objective markers than enemy operatives control, you score 1 VP'
+    ]
+  }, {
+    id: 3,
+    name: 'Get stick in!',
+    revealTime: 'You can reveal this Tac Op in the Reveal Tac Ops step of any turning Point',
+    description: [
+      'At the end of any turning Point (excluding the fourth), if three or more friendly operatives are within ⬟ of your opponents drop zone, you score 1 VP.',
+      'If you achieve the first condition at the end of any subsequent Turning Points (excluding the fourth), you score 1 VP.'
+    ]
+  }
+]
+
+const data = { strategicPloys, tacticalPloys, tacOps }
+
+export default data

--- a/src/components/KillTeam2021/data/veteranGuardsmen.ts
+++ b/src/components/KillTeam2021/data/veteranGuardsmen.ts
@@ -1,0 +1,82 @@
+import { Ploy, TacOp } from '../../../types/KillTeam2021';
+
+const strategicPloys: Ploy[] = [
+  {
+    name: 'Overcharge lasguns',
+    cost: 1,
+    description: 'Until the end of the Turning Point, change the profile of lasguns that friendly VETERAN GUARDSMAN💀 operatives are equipped with to include the following:',
+    weapon: {
+      name: 'Overcharged lasgun',
+      melee: false,
+      attacks: 4,
+      hit: 4,
+      damage: 2,
+      criticalDamage: 3,
+      specialRules: 'AP1, Hot',
+      criticalRules: ''
+    }
+  }, {
+    name: 'Take cover',
+    cost: 1,
+    description: 'Until the end of the Turning Point, each time a shooting attack is made against a friendly VETERAN GUARDSMAN💀 operative, if it is in Cover, improve it\'s Save characteristic by 1 for that shooting attack.',
+  }, {
+    name: 'Into the breach',
+    cost: 1,
+    description: 'Each friendly VETERAN GUARDSMAN💀 operative within your drop zone can perform a free Dash action, but must finish that move closer to the enemy\'s drop zone.',
+  }, {
+    name: 'Clear the line',
+    cost: 1,
+    description: `Until the end of the Turning Point, each time a friendly VETERAN GUARDSMAN💀 operative fights in combat,
+                  before rolling your attack dice for that combat, you can retain one as a successfull normal hit withour rolling it.`,
+  }
+]
+
+const tacticalPloys: Ploy[] = [
+  {
+    name: 'Inspirational leadership',
+    cost: 1,
+    description: `Use this Tactical Ploy during a VETERAN GUARDSMAN💀 LEADER operative's operation. That operative issues a
+                  Guardsman Order to all friendly VETERAN GUARDSMAN💀 operatives within ⬟ of and visible to it.`,
+  }, {
+    name: 'In death, atonement',
+    cost: 1,
+    description: `Use this Tactical Ploy when a ready friendly VETERAN GUARDSMAN💀 operative is incapacitated.
+                  That operative is not removed from the killzone until the end of your next activation and does not count as being injured.`,
+  }, {
+    name: 'Combined arms',
+    cost: 1,
+    description: `Use this Tactival Ploy after rolling your attack dice for a shooting attack made by a friendly VETERAN GUARDSMAN💀 operative.
+                  If the target of that attack is an enemy operative that was targeted by another friendly VETERAN GUARDSMAN💀 operative with a
+                  shooting attack during that Turning point, you can re-roll any or all of your attack dice for that shooting attack.`,
+  }
+]
+
+const tacOps: TacOp[] = [{
+  id: 1,
+  name: 'Boots on the ground',
+  revealTime: 'You can reveal this Tac Op at the end of any Turning Point',
+  description: [
+    `At the end of that Turning Point, if there are more friendly operatives than enemy operatives within ⬟ of your drop zone, and there are more friendly
+     operatives than enemy operatives within ⬟ of your opponent's drop zone, you score 1VP.`,
+    'If you achieve the first condition at the end of any subsequent Turning Points, you score 1VP.'
+  ],
+}, {
+  id: 2,
+  name: 'Stand fast',
+  revealTime: 'You can reveal this Tac Op in the Reveal Tac Ops step of any Turning Point',
+  description: [
+    'At the end of any Turning Point, if friendly operatives control two or more objective markers, and frierndly operatives control more objective markers than enemy operatives, you score 1VP.',
+    'If you achieve the first condition at the end of any subsequent Turning Point, you score an additional 1VP.'
+  ],
+}, {
+  id: 3,
+  name: "Glory in death",
+  revealTime: 'Reveal this Tac Op at the end of the battle',
+  description: [
+    'If more friendly operatives were incapacitated than enemy operatives, but you scored more victory points from the mission objective, you score 2 VPs.'
+  ]
+}]
+
+const data = { strategicPloys, tacticalPloys, tacOps }
+
+export default data

--- a/src/parsers/KillTeam2021/BattlescribeParser.ts
+++ b/src/parsers/KillTeam2021/BattlescribeParser.ts
@@ -125,6 +125,7 @@ const parseOperative = (model : Element) : Operative => {
 export const parseBattlescribeXML = (doc : Document) : Roster => {
   const operatives = []
   const name = xpSelect('string(/bs:roster/@name)', doc, true).toString()
+  const faction = xpSelect('string(//bs:force/@catalogueName)', doc, true).toString()
   for (const model of xpSelect('//bs:selection[@type=\'model\']', doc) as Element[]) {
     operatives.push(parseOperative(model))
   }
@@ -148,6 +149,7 @@ export const parseBattlescribeXML = (doc : Document) : Roster => {
   return {
     system: "KillTeam2021",
     name,
+    faction,
     operatives,
     psychicPowers
   }

--- a/src/types/KillTeam2021.ts
+++ b/src/types/KillTeam2021.ts
@@ -33,6 +33,21 @@ export type PsychicPower = {
   weapon: Weapon | null;
 }
 
+export type Ploy = {
+  name: string;
+  cost: number;
+  description: any;
+  weapon?: Weapon
+}
+
+export type TacOp = {
+  id: number;
+  name: string;
+  revealTime: string;
+  description: string[];
+  action?: Action;
+}
+
 export type Equipment = {
   name: string,
   cost: number,
@@ -71,6 +86,7 @@ export type Datacard = {
 export type Roster = {
   system: string,
   name: string,
+  faction: string,
   operatives: Operative[],
   psychicPowers: PsychicPower[],
 };


### PR DESCRIPTION
I am submitting initial PR about inclusion of faction-specific data with you, in order to agree on the approach.

This PR does the following:

1. Expands the `Roster` type with a `faction` string
2. Expands parsing of the KT2021 roster to fetch the faction from it
3. Expands the `Roster` component from KT2021 with a `faction` prop
4. Passess the `faction`, as parsed from the Battlescribe roster, to the `Roster` component.
5. Adds `./data/veteranGuardsmen,ts` file, which exports an object containing veteran guardsmen specific strategic ploys, tactical ploys and tac ops
6. Adds `./data/index`, which exports a function. Function accepts the name of a faction, and returns faction speficic strategic ploys etc.
7. Adds `PloysColumn` component. At the time, it's nearly a copy-paste of the `PowerList`
8. In the `Roster` component fetch the faction specific data, and if it's there, render the strategic ploys and tactical ploys using the `PloysColumn` component, and some styling.

Like I mentioned, this is an initial version, so that I can show you how I am thinking to organise this and get initial feedback.
This is missing the following:
1. Tac Ops rendering
2. I would like to render the ploys as 2 parallel columns, as it is in the Octarius book. They need prices present as well.

Thoughts?