### PR TITLE
Hunter Cadre and Hunter Clade data files

### DIFF
--- a/src/components/KillTeam2021/data/hunterCadre.ts
+++ b/src/components/KillTeam2021/data/hunterCadre.ts
@@ -1,0 +1,56 @@
+import { Ploy } from '../../../types/KillTeam2021';
+
+const strategicPloys: Ploy[] = [
+  {
+    name: 'Aimed Pulse Volley',
+    cost: 1,
+    description: `Until the end of the Turning Point, each time a friendly FIRE WARRIOR operative makes a shooting attack with a pulse rifle as a result of a Shoot action, in the 
+                  Roll Attack Dice step of that shooting attack, if it has not moved during that activation, you can re-roll one of your attack dice.`
+  }, {
+    name: 'Breach and Clear',
+    cost: 1,
+    description: `Until the end of the Turning Point, each time a friendly FIRE WARRIOR operative makes a shooting attack with a pulse blaster as a result of a Shoot action:`,
+    options: [
+      `For that shooting attack, enemy operatives within ■ of it are not in Cover.`,
+      `In the Roll Attack Dice step of that shooting attack, if the target is within ■ of it, you can re-roll one of your attack dice.`
+    ]
+  }, {
+    name: 'Camouflage Field Engagement',
+    cost: 1,
+    description: `Until the end of the Turning Point, friendly STEALTH BATTLESUIT operatives can perform the following action:`,
+    action: {
+      name: 'Camouflage Field Engagement',
+      cost: 1,
+      description: `Change this operative's order.`
+    }
+  }, {
+    name: 'Recon Sweep',
+    cost: 1,
+    description: `Friendly PATHFINDER operatives that are wholly within ⬟ of any killzone edge can immediately perform a free Dash action, but only if they can finish that move 
+                  wholly within ⬟ of a killzone edge that is not your own killzone edge.`
+  }
+]
+
+const tacticalPloys: Ploy[] = [
+  {
+    name: 'Supporting Fire',
+    cost: 1,
+    description: `Use this Tactical Ploy in the Firefight phase, when a Shoot action is declared for a friendly HUNTER CADRE💀 operative.In the Select Valid Target step of that
+                  shooting attack, you must select an enemy operative that is within Engagement Range of one or more other friendly operatives and within ⬟ of the active operative,
+                  and that enemy operative cannot be in Cover as a result of friendly operative's bases. Note, however that in the Roll Defence Dice step of that shooting attack, 
+                  the enemy operative can be in Cover as a result of friendly operatives' bases.`
+  }, {
+    name: 'Stand and Fire',
+    cost: 1,
+    description: `Use this Tactical Ploy when a friendly HUNTER CADRE💀 operative (excluding a DRONE operative) is selected as the target for combat. For that combat:`,
+    options: [
+        `Select a ranged weapon to fight with.`,
+        `Treat that weapon's Ballistic Skill characteristic as a Weapon Skill characteristic.`,
+        `Ignore any special rules that weapon has.`
+    ]
+  }
+]
+
+const data = { strategicPloys, tacticalPloys, tacOps: null }
+
+export default data

--- a/src/components/KillTeam2021/data/hunterClade.ts
+++ b/src/components/KillTeam2021/data/hunterClade.ts
@@ -1,4 +1,4 @@
-import { Ploy } from '../../../types/KillTeam2021';
+import {Ploy, TacOp} from '../../../types/KillTeam2021';
 
 const strategicPloys: Ploy[] = [
   {
@@ -62,6 +62,37 @@ const tacticalPloys: Ploy[] = [
   },
 ]
 
-const data = { strategicPloys, tacticalPloys, tacOps: null }
+
+const tacOps: TacOp[] = [
+  {
+    id: 1,
+    name: 'Relentless Pursuit',
+    revealTime: `You can reveal this Tac Op in the Target Reveal step of any Turning Point.`,
+    description: [
+        'At the end of any Turning Point, if there are no enemy operatives in the killzone more than ⬟ from friendly operatives, you score 1VP.',
+        'If you achieve the first condition in any subsequent Turning Points, you score 1VP.'
+    ],
+  }, {
+    id: 2,
+    name: 'Calculated Eradication',
+    revealTime: 'Reveal this TacOp when a Doctrina Imperative first becomes active for your kill team.',
+    description: [
+      `At the end of any Turning Point, if an Imperative is active for your kill team, and the total wounds lost by enemy operatives during that Turning Point is greater than
+      that lost by friendly operatives, you score 1VP`,
+      `At the end of any Turning Point, if a different Imperative is active for your kill team, and the total wounds lost by enemy operatives during that Turning Point is 
+      greater than that lost by friendly operatives, you score 1VP`
+    ]
+  }, {
+    id: 3,
+    name: 'Assassination Order',
+    revealTime: 'Reveal this Tac Op in the Target Reveal step of the first Turning Point. Your opponent selects one of their operatives.',
+    description: [
+      'If that enemy operative is incapacitated before the fourth Turning Point, you score 1VP.',
+      'If the first condition is achieved by a friendly HUNTER CLADE💀 operative within ■ of that enemy operative, you score 1VP.'
+    ]
+  }
+]
+
+const data = { strategicPloys, tacticalPloys, tacOps }
 
 export default data

--- a/src/components/KillTeam2021/data/hunterClade.ts
+++ b/src/components/KillTeam2021/data/hunterClade.ts
@@ -1,0 +1,67 @@
+import { Ploy } from '../../../types/KillTeam2021';
+
+const strategicPloys: Ploy[] = [
+  {
+    name: 'Martial Protocol',
+    cost: 1,
+    description: `Until the end of the Turning Point:`,
+    options: [
+        `Each time a friendly HUNTER CLADE💀 VANGUARD operative that is within ⬤ of an objective marker or within ⬟ of your opponent's drop zone make a shooting attack,
+        in the Roll Attack Dice step of that shooting attack, you can re-roll one of your attack dice.`,
+        `Each time a friendly HUNTER CLADE💀 RANGER operative that has not moved during the Turning Point makes a shooting attack, in the Roll Attack Dice step of that shooting 
+        attack, you can re-roll one of your attack dice.`
+    ]
+  }, {
+    name: 'Accelerant Agents',
+    cost: 1,
+    description: `Until the end of the Turning Point, each time a friendly HUNTER CLADE💀 RUSTSTALKER operative is activated:`,
+    options: [
+      `It can perform a free Fight action during that activation`,
+      `It can perform two Fight actions during that activation`
+    ]
+  }, {
+    name: 'Neurostatic Interference',
+    cost: 1,
+    description: `Until the end of the Turning Point, while an enemy operative is within ⬟ of a friendly HUNTER CLADE💀 INFILTRATOR operative, each time that enemy operative
+                  fights in combat or makes a shooting attack, in the Roll Attack Dice step of that combat or shooting attack, your opponent cannot re-roll their attack dice.`,
+  }, {
+    name: 'Calculated Approach',
+    cost: 1,
+    description: `Until the end of the Turning Point, each time a shooting attack is made against a friendly HUNTER CLADE💀 operative that is more than ⬟ from enemy operatives,
+                  in the Roll Defence Dice step of that shooting attack, if you retain any critical saves, you can select one of your failed saves to be retained as a successful
+                  normal save.`
+  }
+]
+
+const tacticalPloys: Ploy[] = [
+  {
+    name: 'Pursuers',
+    cost: 1,
+    description: `Use this Tactical Ploy in the Scouting step of the mission sequence, when you resolve your scouting option.`,
+    options: [
+        `If you selected the Recon option, you can also perform a free Dash action with up to two friendly HUNTER CLADE💀 RANGER operatives that are wholly within your drop zone`,
+        `If you selected the Infiltrate option, during the first Turning Point, you can also change the order of up to two ready friendly HUNTER CLADE💀 RANGER operatives when
+         each of them are activated`
+        ]
+  }, {
+    name: 'Command Override',
+    cost: 1,
+    description: `Use this Tactical Ploy when a ready friendly HUNTER CLADE💀 operative is activated. Select one Doctrina Imperative that is not active for your kill team. Until
+                  the end of the Turning Point, that Imperative is treated as being active for that operative instead of the current active Imperative`,
+  }, {
+    name: 'Concealed Position',
+    cost: 1,
+    description: `Use this Tactical Ploy in the Set Up Operatives step of the mission sequence. Select one friendly HUNTER CLADE💀 INFILTRATOR operative. That operative can be 
+                  set up with a Conceal order anywhere in the killzone that is within ▲ of Heavy terrain and more than ⬟ from enemy operatives and the enemy drop zone. That
+                  operative cannot have its order changed during the first Turning Point as a result of the Infiltrate option in the Scouting step. You can only use this Tactical
+                  Ploy once.`,
+  }, {
+    name: 'Motive Force Vitality',
+    cost: 1,
+    description: `Use this Tactical Ploy when a ready friendly HUNTER CLADE💀 operative is activated. That operative regains D3 lost wounds.`,
+  },
+]
+
+const data = { strategicPloys, tacticalPloys, tacOps: null }
+
+export default data

--- a/src/components/KillTeam2021/data/index.ts
+++ b/src/components/KillTeam2021/data/index.ts
@@ -11,6 +11,7 @@ import talonsOfTheEmporer from "./talonsOfTheEmporer";
 import traitorSpaceMarine from "./traitorSpaceMarine";
 import deathGuard from "./deathGuard";
 import thousandSons from "./thousandSons";
+import hunterCadre from "./hunterCadre";
 
 const getFactionSpecificData = (factionName: string) => {
   switch (factionName) {
@@ -40,6 +41,8 @@ const getFactionSpecificData = (factionName: string) => {
       return deathGuard;
     case "Thousand Sons":
       return thousandSons;
+    case "Hunter Cadre":
+      return hunterCadre;
     default:
       return null;
   }

--- a/src/components/KillTeam2021/data/index.ts
+++ b/src/components/KillTeam2021/data/index.ts
@@ -12,6 +12,7 @@ import traitorSpaceMarine from "./traitorSpaceMarine";
 import deathGuard from "./deathGuard";
 import thousandSons from "./thousandSons";
 import hunterCadre from "./hunterCadre";
+import hunterClade from "./hunterClade";
 
 const getFactionSpecificData = (factionName: string) => {
   switch (factionName) {
@@ -43,6 +44,8 @@ const getFactionSpecificData = (factionName: string) => {
       return thousandSons;
     case "Hunter Cadre":
       return hunterCadre;
+    case "Hunter Clade":
+      return hunterClade;
     default:
       return null;
   }


### PR DESCRIPTION
Annoying GW having two factions very similarly named!

For Hunter Clade (AdMech from White Dwarf mag), this file has the Strategic Ploys, Tactical Ploys, and the faction specific Tac Ops. However the app doesn't currently display Doctrina Imperatives from the BattleScribe file.