### PR TITLE
Faction archetypes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,7 +40,7 @@ export function App() {
     <Container fluid='lg'>
       {roster === null ? <Homepage onUpload={handleUpload} /> : <></>}
       {roster && isRosterKT18(roster) ? <RosterView2018 name={roster.name} models={roster.models} onClose={handleClose} forceRules={roster.forceRules} onSelectionChanged={handleSelectionChanged} /> : <></>}
-      {roster && isRosterKT21(roster) ? <RosterView2021 name={roster.name} operatives={roster.operatives} psychicPowers={roster.psychicPowers} faction={roster.faction} onClose={handleClose} /> : <></>}
+      {roster && isRosterKT21(roster) ? <RosterView2021 name={roster.name} operatives={roster.operatives} psychicPowers={roster.psychicPowers} faction={roster.faction} fireteams={roster.fireteams} onClose={handleClose} /> : <></>}
     </Container>
   )
 }

--- a/src/components/KillTeam2021/ArchetypeBadge.tsx
+++ b/src/components/KillTeam2021/ArchetypeBadge.tsx
@@ -8,8 +8,11 @@ type Props = {
 export function ArchetypeBadge (props: Props) {
 
     return (
-        <Badge pill variant="dark" className="w-25 px-5">
-            <div className="text-light">{props.archetype}</div>
+        <Badge pill variant="secondary" className="mb-2" style={{
+            textTransform: "uppercase",
+            marginRight: "10px",
+        }}>
+        {props.archetype}
         </Badge>
     )
 }

--- a/src/components/KillTeam2021/ArchetypeBadge.tsx
+++ b/src/components/KillTeam2021/ArchetypeBadge.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { Badge } from 'react-bootstrap'
+
+type Props = {
+    archetype: string|null,
+}
+
+export function ArchetypeBadge (props: Props) {
+
+    return (
+        <Badge pill variant="dark" className="w-25 px-5">
+            <div className="text-light">{props.archetype}</div>
+        </Badge>
+    )
+}

--- a/src/components/KillTeam2021/Roster.tsx
+++ b/src/components/KillTeam2021/Roster.tsx
@@ -16,6 +16,7 @@ type Props = {
   faction: string,
   operatives: Operative[],
   psychicPowers: PsychicPower[],
+  fireteams: string[],
   onClose: (event: MouseEvent<HTMLButtonElement>) => void,
 };
 
@@ -38,6 +39,20 @@ export function Roster(props: Props) {
   };
   const datacards = groupByDatacard(props.operatives)
   const factionSpecificData = getFactionSpecificData(props.faction)
+
+  let archetypes = props.fireteams.map( (fireteam) => {
+    if (factionSpecificData !== null && factionSpecificData.fireteamArchetypeMap !== null) {
+      return (factionSpecificData.fireteamArchetypeMap[fireteam] as string[])
+    } else {
+      return null
+    }
+  }).filter( val =>  val !== null ).flat(1)
+
+  // Now remove duplicates
+  archetypes = (archetypes.filter( (item,index) => archetypes.indexOf(item) === index))
+  console.log(archetypes)
+
+
 
   return <>
     <h1 style={headingStyle}>

--- a/src/components/KillTeam2021/Roster.tsx
+++ b/src/components/KillTeam2021/Roster.tsx
@@ -1,5 +1,5 @@
 import React, { MouseEvent } from 'react';
-import { Col, Card } from 'react-bootstrap';
+import {Col, Card, Badge} from 'react-bootstrap';
 import { CloseButton } from '../CloseButton';
 import { Operative, Datacard, PsychicPower } from '../../types/KillTeam2021';
 import { Datasheet } from './Datasheet';
@@ -10,6 +10,7 @@ import { TacOpsList } from './TacOpsList';
 import hash from 'node-object-hash'
 import _ from 'lodash'
 import getFactionSpecificData from './data'
+import {ArchetypeBadge} from "./ArchetypeBadge";
 
 type Props = {
   name: string,
@@ -95,16 +96,17 @@ export function Roster(props: Props) {
             </Card.Body>
           </Card>
         </div>
-        {
-          factionSpecificData.tacOps &&
-            <Card>
-              <Card.Header style={{...headingStyle}} as="h2">Tac Ops</Card.Header>
-              <Card.Body>
-                <TacOpsList tacOps={factionSpecificData.tacOps} />
-              </Card.Body>
-            </Card>
-        }
+
       </div>
+    }
+    { ((factionSpecificData && factionSpecificData.tacOps) || (archetypes.length > 0)) &&
+      <Card>
+        <Card.Header style={{...headingStyle}} as="h2">Tac Ops</Card.Header>
+        <Card.Body>
+          { archetypes.length > 0 && <> <h4>ARCHETYPES</h4> {archetypes.map(archetype => { return <ArchetypeBadge archetype={archetype}/> } )} </> }
+          { factionSpecificData && factionSpecificData.tacOps && <TacOpsList tacOps={factionSpecificData.tacOps} /> }
+        </Card.Body>
+      </Card>
     }
   </>
 }

--- a/src/components/KillTeam2021/Roster.tsx
+++ b/src/components/KillTeam2021/Roster.tsx
@@ -103,7 +103,9 @@ export function Roster(props: Props) {
       <Card>
         <Card.Header style={{...headingStyle}} as="h2">Tac Ops</Card.Header>
         <Card.Body>
-          { archetypes.length > 0 && <> <h4>ARCHETYPES</h4> {archetypes.map(archetype => { return <ArchetypeBadge archetype={archetype}/> } )} </> }
+          { archetypes.length > 0 &&
+            <Card.Title>ARCHETYPES - {archetypes.map(archetype => { return <ArchetypeBadge archetype={archetype}/> } )}</Card.Title>}
+
           { factionSpecificData && factionSpecificData.tacOps && <TacOpsList tacOps={factionSpecificData.tacOps} /> }
         </Card.Body>
       </Card>

--- a/src/components/KillTeam2021/data/broodCoven.ts
+++ b/src/components/KillTeam2021/data/broodCoven.ts
@@ -41,6 +41,6 @@ const tacticalPloys: Ploy[] = [
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, tacOps: null }
+const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap: null, tacOps: null }
 
 export default data

--- a/src/components/KillTeam2021/data/broodCoven.ts
+++ b/src/components/KillTeam2021/data/broodCoven.ts
@@ -1,4 +1,10 @@
-import { Ploy } from '../../../types/KillTeam2021';
+import {Archetype, FireteamArchetypes, Ploy} from '../../../types/KillTeam2021';
+
+const fireteamArchetypeMap: FireteamArchetypes = {
+  "Neophyte Hybrid Fire Team": [Archetype.SECURITY, Archetype.RECON, Archetype.INFILTRATION],
+  "Acolyte Hybrid Fire Team": [Archetype.SEEK_AND_DESTROY, Archetype.INFILTRATION],
+  "Hybrid Metamorph Fire Team": [Archetype.SEEK_AND_DESTROY],
+}
 
 const strategicPloys: Ploy[] = [
   {
@@ -41,6 +47,6 @@ const tacticalPloys: Ploy[] = [
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap: null, tacOps: null }
+const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap, tacOps: null }
 
 export default data

--- a/src/components/KillTeam2021/data/cadreMercenary.ts
+++ b/src/components/KillTeam2021/data/cadreMercenary.ts
@@ -42,6 +42,6 @@ const tacticalPloys: Ploy[] = [
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, tacOps: null }
+const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap: null, tacOps: null }
 
 export default data

--- a/src/components/KillTeam2021/data/cadreMercenary.ts
+++ b/src/components/KillTeam2021/data/cadreMercenary.ts
@@ -1,4 +1,8 @@
-import { Ploy } from '../../../types/KillTeam2021';
+import {Archetype, FireteamArchetypes, Ploy} from '../../../types/KillTeam2021';
+
+const fireteamArchetypeMap: FireteamArchetypes = {
+  "Cadre Mercenary Kill Team": [Archetype.SEEK_AND_DESTROY, Archetype.INFILTRATION, Archetype.RECON],
+}
 
 const strategicPloys: Ploy[] = [
   {
@@ -42,6 +46,6 @@ const tacticalPloys: Ploy[] = [
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap: null, tacOps: null }
+const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap, tacOps: null }
 
 export default data

--- a/src/components/KillTeam2021/data/deathGuard.ts
+++ b/src/components/KillTeam2021/data/deathGuard.ts
@@ -1,4 +1,9 @@
-import { Ploy } from '../../../types/KillTeam2021';
+import {Archetype, FireteamArchetypes, Ploy} from '../../../types/KillTeam2021';
+
+const fireteamArchetypeMap: FireteamArchetypes = {
+  "Plague Marine Fire Team": [Archetype.SEEK_AND_DESTROY, Archetype.SECURITY],
+  "Poxwalker Fire Team" : [Archetype.INFILTRATION, Archetype.SECURITY],
+}
 
 const strategicPloys: Ploy[] = [
   {
@@ -44,6 +49,6 @@ const tacticalPloys: Ploy[] = [
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, tacOps: null }
+const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap, tacOps: null }
 
 export default data

--- a/src/components/KillTeam2021/data/ecclesiarchy.ts
+++ b/src/components/KillTeam2021/data/ecclesiarchy.ts
@@ -1,4 +1,10 @@
-import { Ploy } from '../../../types/KillTeam2021';
+import {Archetype, FireteamArchetypes, Ploy} from '../../../types/KillTeam2021';
+
+const fireteamArchetypeMap: FireteamArchetypes = {
+  "Battle Sister Fire Team": [Archetype.SECURITY],
+  "Repentia Fire Team" : [Archetype.SEEK_AND_DESTROY],
+  "Arco-Flagellant Fire Team" : [Archetype.SEEK_AND_DESTROY],
+}
 
 const strategicPloys: Ploy[] = [
   {
@@ -43,6 +49,6 @@ const tacticalPloys: Ploy[] = [
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, tacOps: null }
+const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap, tacOps: null }
 
 export default data

--- a/src/components/KillTeam2021/data/forgeWorld.ts
+++ b/src/components/KillTeam2021/data/forgeWorld.ts
@@ -55,6 +55,6 @@ const tacticalPloys: Ploy[] = [
 
 ]
 
-const data = { strategicPloys, tacticalPloys, tacOps: null }
+const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap: null, tacOps: null }
 
 export default data

--- a/src/components/KillTeam2021/data/forgeWorld.ts
+++ b/src/components/KillTeam2021/data/forgeWorld.ts
@@ -1,4 +1,10 @@
-import { Ploy } from '../../../types/KillTeam2021';
+import {Archetype, FireteamArchetypes, Ploy} from '../../../types/KillTeam2021';
+
+const fireteamArchetypeMap: FireteamArchetypes = {
+  "Skitarii Ranger Fire Team": [Archetype.RECON, Archetype.SECURITY],
+  "Skitarii Vanguard Fire Team": [Archetype.SECURITY],
+  "Sicarian Fire Team": [Archetype.SEEK_AND_DESTROY, Archetype.INFILTRATION, Archetype.RECON],
+}
 
 const strategicPloys: Ploy[] = [
   {
@@ -55,6 +61,6 @@ const tacticalPloys: Ploy[] = [
 
 ]
 
-const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap: null, tacOps: null }
+const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap, tacOps: null }
 
 export default data

--- a/src/components/KillTeam2021/data/greenskin.ts
+++ b/src/components/KillTeam2021/data/greenskin.ts
@@ -1,4 +1,10 @@
-import { Ploy } from '../../../types/KillTeam2021';
+import {Archetype, FireteamArchetypes, Ploy} from '../../../types/KillTeam2021';
+
+const fireteamArchetypeMap: FireteamArchetypes = {
+  "Boy Fire Team": [Archetype.SEEK_AND_DESTROY, Archetype.SECURITY],
+  "Clan Kommando Fire Team": [Archetype.SEEK_AND_DESTROY, Archetype.INFILTRATION],
+  "Speshulist Fire Team": [Archetype.SEEK_AND_DESTROY],
+}
 
 const strategicPloys: Ploy[] = [
   {
@@ -36,6 +42,6 @@ const tacticalPloys: Ploy[] = [
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap: null, tacOps: null }
+const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap, tacOps: null }
 
 export default data

--- a/src/components/KillTeam2021/data/greenskin.ts
+++ b/src/components/KillTeam2021/data/greenskin.ts
@@ -36,6 +36,6 @@ const tacticalPloys: Ploy[] = [
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, tacOps: null }
+const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap: null, tacOps: null }
 
 export default data

--- a/src/components/KillTeam2021/data/greyKnights.ts
+++ b/src/components/KillTeam2021/data/greyKnights.ts
@@ -39,6 +39,6 @@ const tacticalPloys: Ploy[] = [
 
 ]
 
-const data = { strategicPloys, tacticalPloys, tacOps: null }
+const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap: null, tacOps: null }
 
 export default data

--- a/src/components/KillTeam2021/data/greyKnights.ts
+++ b/src/components/KillTeam2021/data/greyKnights.ts
@@ -1,4 +1,8 @@
-import { Ploy } from '../../../types/KillTeam2021';
+import {Archetype, FireteamArchetypes, Ploy} from '../../../types/KillTeam2021';
+
+const fireteamArchetypeMap: FireteamArchetypes = {
+  "Grey Knight Kill Team": [Archetype.SEEK_AND_DESTROY, Archetype.SECURITY],
+}
 
 const strategicPloys: Ploy[] = [
   {
@@ -39,6 +43,6 @@ const tacticalPloys: Ploy[] = [
 
 ]
 
-const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap: null, tacOps: null }
+const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap, tacOps: null }
 
 export default data

--- a/src/components/KillTeam2021/data/hiveFleet.ts
+++ b/src/components/KillTeam2021/data/hiveFleet.ts
@@ -33,6 +33,6 @@ const tacticalPloys: Ploy[] = [
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, tacOps: null }
+const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap: null, tacOps: null }
 
 export default data

--- a/src/components/KillTeam2021/data/hiveFleet.ts
+++ b/src/components/KillTeam2021/data/hiveFleet.ts
@@ -1,4 +1,10 @@
-import { Ploy } from '../../../types/KillTeam2021';
+import {Archetype, FireteamArchetypes, Ploy} from '../../../types/KillTeam2021';
+
+const fireteamArchetypeMap: FireteamArchetypes = {
+  "Tyranid Warrior Fire Team": [Archetype.SEEK_AND_DESTROY, Archetype.SECURITY],
+  "Genestealer Fire Team": [Archetype.SEEK_AND_DESTROY, Archetype.INFILTRATION],
+  "Tyranid Swarm Fire Team": [Archetype.SEEK_AND_DESTROY, Archetype.SECURITY, Archetype.RECON],
+}
 
 const strategicPloys: Ploy[] = [
   {
@@ -33,6 +39,6 @@ const tacticalPloys: Ploy[] = [
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap: null, tacOps: null }
+const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap, tacOps: null }
 
 export default data

--- a/src/components/KillTeam2021/data/hunterCadre.ts
+++ b/src/components/KillTeam2021/data/hunterCadre.ts
@@ -1,4 +1,10 @@
-import { Ploy } from '../../../types/KillTeam2021';
+import {Archetype, FireteamArchetypes, Ploy} from '../../../types/KillTeam2021';
+
+const fireteamArchetypeMap: FireteamArchetypes = {
+  "Fire Warrior Fire Team": [Archetype.SECURITY],
+  "Pathfinder Fire Team": [Archetype.RECON],
+  "Stealth Battlesuit Fire Team": [Archetype.INFILTRATION, Archetype.RECON],
+}
 
 const strategicPloys: Ploy[] = [
   {
@@ -51,6 +57,6 @@ const tacticalPloys: Ploy[] = [
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap: null, tacOps: null }
+const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap, tacOps: null }
 
 export default data

--- a/src/components/KillTeam2021/data/hunterCadre.ts
+++ b/src/components/KillTeam2021/data/hunterCadre.ts
@@ -51,6 +51,6 @@ const tacticalPloys: Ploy[] = [
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, tacOps: null }
+const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap: null, tacOps: null }
 
 export default data

--- a/src/components/KillTeam2021/data/hunterClade.ts
+++ b/src/components/KillTeam2021/data/hunterClade.ts
@@ -1,4 +1,10 @@
-import {Ploy, TacOp} from '../../../types/KillTeam2021';
+import {Archetype, FireteamArchetypes, Ploy, TacOp} from '../../../types/KillTeam2021';
+
+const fireteamArchetypeMap: FireteamArchetypes = {
+  // 05/09/2021 - BattleScribe data currently has Fire Team, where it should probably be Kill Team - have submitted PR to BSData but also coding around it for now below
+  "Hunter Clade Kill Team": [Archetype.RECON, Archetype.SEEK_AND_DESTROY],
+  "Hunter Clade Fire Team": [Archetype.RECON, Archetype.SEEK_AND_DESTROY],
+}
 
 const strategicPloys: Ploy[] = [
   {
@@ -93,6 +99,6 @@ const tacOps: TacOp[] = [
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap: null,  tacOps }
+const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap,  tacOps }
 
 export default data

--- a/src/components/KillTeam2021/data/hunterClade.ts
+++ b/src/components/KillTeam2021/data/hunterClade.ts
@@ -93,6 +93,6 @@ const tacOps: TacOp[] = [
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, tacOps }
+const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap: null,  tacOps }
 
 export default data

--- a/src/components/KillTeam2021/data/imperialGuard.ts
+++ b/src/components/KillTeam2021/data/imperialGuard.ts
@@ -40,6 +40,6 @@ const tacticalPloys: Ploy[] = [
 
 ]
 
-const data = { strategicPloys, tacticalPloys, tacOps: null }
+const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap: null, tacOps: null }
 
 export default data

--- a/src/components/KillTeam2021/data/imperialGuard.ts
+++ b/src/components/KillTeam2021/data/imperialGuard.ts
@@ -1,4 +1,9 @@
-import { Ploy } from '../../../types/KillTeam2021';
+import {Archetype, FireteamArchetypes, Ploy} from '../../../types/KillTeam2021';
+
+const fireteamArchetypeMap: FireteamArchetypes = {
+  "Guardsman Fire Team": [Archetype.SECURITY],
+  "Tempestus Scion Fire Team": [Archetype.SECURITY, Archetype.SEEK_AND_DESTROY, Archetype.INFILTRATION, Archetype.RECON],
+}
 
 const strategicPloys: Ploy[] = [
   {
@@ -40,6 +45,6 @@ const tacticalPloys: Ploy[] = [
 
 ]
 
-const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap: null, tacOps: null }
+const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap, tacOps: null }
 
 export default data

--- a/src/components/KillTeam2021/data/kommando.ts
+++ b/src/components/KillTeam2021/data/kommando.ts
@@ -1,4 +1,8 @@
-import { Ploy, TacOp } from '../../../types/KillTeam2021';
+import {Archetype, FireteamArchetypes, Ploy, TacOp} from '../../../types/KillTeam2021';
+
+const fireteamArchetypeMap: FireteamArchetypes = {
+  "Kommando Kill Team": [Archetype.SEEK_AND_DESTROY, Archetype.INFILTRATION],
+}
 
 const strategicPloys: Ploy[] = [
   {
@@ -74,6 +78,6 @@ const tacOps: TacOp[] = [
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap: null, tacOps }
+const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap, tacOps }
 
 export default data

--- a/src/components/KillTeam2021/data/kommando.ts
+++ b/src/components/KillTeam2021/data/kommando.ts
@@ -74,6 +74,6 @@ const tacOps: TacOp[] = [
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, tacOps }
+const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap: null, tacOps }
 
 export default data

--- a/src/components/KillTeam2021/data/spaceMarine.ts
+++ b/src/components/KillTeam2021/data/spaceMarine.ts
@@ -1,4 +1,16 @@
-import { Ploy } from '../../../types/KillTeam2021';
+import {Archetype, FireteamArchetypes, Ploy} from '../../../types/KillTeam2021';
+
+const fireteamArchetypeMap: FireteamArchetypes = {
+  "Intercessor Fire Team": [Archetype.SEEK_AND_DESTROY, Archetype.SECURITY],
+  "Assault Intercessor Fire Team" : [Archetype.SEEK_AND_DESTROY, Archetype.SECURITY],
+  "Incursor Fire Team" : [Archetype.SEEK_AND_DESTROY, Archetype.INFILTRATION, Archetype.RECON],
+  "Infiltrator Fire Team" : [Archetype.SEEK_AND_DESTROY, Archetype.INFILTRATION, Archetype.RECON],
+  "Reiver Fire Team" : [Archetype.SEEK_AND_DESTROY, Archetype.INFILTRATION, Archetype.RECON],
+  "Heavy Intercessor Fire Team" : [Archetype.SEEK_AND_DESTROY, Archetype.SECURITY],
+  "Tactical Marine Fire Team" : [Archetype.SEEK_AND_DESTROY, Archetype.SECURITY],
+  "Scout Fire Team" : [Archetype.SEEK_AND_DESTROY, Archetype.INFILTRATION, Archetype.RECON],
+  "Death Watch Fire Team" : [Archetype.SEEK_AND_DESTROY, Archetype.SECURITY],
+}
 
 const strategicPloys: Ploy[] = [
   {
@@ -59,6 +71,6 @@ const tacticalPloys: Ploy[] = [
 
 ]
 
-const data = { strategicPloys, tacticalPloys, tacOps: null }
+const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap, tacOps: null, }
 
 export default data

--- a/src/components/KillTeam2021/data/talonsOfTheEmporer.ts
+++ b/src/components/KillTeam2021/data/talonsOfTheEmporer.ts
@@ -1,4 +1,9 @@
-import { Ploy } from '../../../types/KillTeam2021';
+import {Archetype, FireteamArchetypes, Ploy} from '../../../types/KillTeam2021';
+
+const fireteamArchetypeMap: FireteamArchetypes = {
+  "Custodian Guard Fire Team": [Archetype.SEEK_AND_DESTROY, Archetype.SECURITY],
+  "Sister of Silence Fire Team": [Archetype.SEEK_AND_DESTROY, Archetype.SECURITY, Archetype.RECON],
+}
 
 const strategicPloys: Ploy[] = [
   {
@@ -15,7 +20,6 @@ const strategicPloys: Ploy[] = [
     name: 'Peerless Warriors',
     cost: 1,
     description: `Until the end of the Turning Point, each time a friendly ADEPTUS CUSTODES operative is activated, it can perform up to two Shoot and Fight actions during that activation.`,
-
   }
 ]
 
@@ -42,6 +46,6 @@ const tacticalPloys: Ploy[] = [
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap: null, tacOps: null }
+const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap, tacOps: null }
 
 export default data

--- a/src/components/KillTeam2021/data/talonsOfTheEmporer.ts
+++ b/src/components/KillTeam2021/data/talonsOfTheEmporer.ts
@@ -42,6 +42,6 @@ const tacticalPloys: Ploy[] = [
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, tacOps: null }
+const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap: null, tacOps: null }
 
 export default data

--- a/src/components/KillTeam2021/data/thousandSons.ts
+++ b/src/components/KillTeam2021/data/thousandSons.ts
@@ -40,6 +40,6 @@ const tacticalPloys: Ploy[] = [
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, tacOps: null }
+const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap: null, tacOps: null }
 
 export default data

--- a/src/components/KillTeam2021/data/thousandSons.ts
+++ b/src/components/KillTeam2021/data/thousandSons.ts
@@ -1,4 +1,11 @@
-import { Ploy } from '../../../types/KillTeam2021';
+import {Archetype, FireteamArchetypes, Ploy} from '../../../types/KillTeam2021';
+
+const fireteamArchetypeMap: FireteamArchetypes = {
+  // 05/09/2021 - BattleScribe data currently has Kill Team, where it should probably be Fire Team - have submitted PR to BSData but also coding around it for now below
+  "Rubric Marine Kill Team": [Archetype.SEEK_AND_DESTROY, Archetype.SECURITY],
+  "Rubric Marine Fire Team": [Archetype.SEEK_AND_DESTROY, Archetype.SECURITY],
+  "Tzaangor Fire Team": [Archetype.SEEK_AND_DESTROY, Archetype.RECON],
+}
 
 const strategicPloys: Ploy[] = [
   {
@@ -40,6 +47,6 @@ const tacticalPloys: Ploy[] = [
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap: null, tacOps: null }
+const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap, tacOps: null }
 
 export default data

--- a/src/components/KillTeam2021/data/traitorSpaceMarine.ts
+++ b/src/components/KillTeam2021/data/traitorSpaceMarine.ts
@@ -41,6 +41,6 @@ const tacticalPloys: Ploy[] = [
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, tacOps: null }
+const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap: null, tacOps: null }
 
 export default data

--- a/src/components/KillTeam2021/data/traitorSpaceMarine.ts
+++ b/src/components/KillTeam2021/data/traitorSpaceMarine.ts
@@ -1,4 +1,9 @@
-import { Ploy } from '../../../types/KillTeam2021';
+import {Archetype, FireteamArchetypes, Ploy} from '../../../types/KillTeam2021';
+
+const fireteamArchetypeMap: FireteamArchetypes = {
+  "Chaos Space Marine Fire Team": [Archetype.SEEK_AND_DESTROY, Archetype.RECON, Archetype.INFILTRATION, Archetype.SECURITY],
+  "Chaos Cultist Fire Team": [Archetype.RECON, Archetype.INFILTRATION],
+}
 
 const strategicPloys: Ploy[] = [
   {
@@ -41,6 +46,6 @@ const tacticalPloys: Ploy[] = [
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap: null, tacOps: null }
+const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap, tacOps: null }
 
 export default data

--- a/src/components/KillTeam2021/data/troupe.ts
+++ b/src/components/KillTeam2021/data/troupe.ts
@@ -1,4 +1,8 @@
-import { Ploy } from '../../../types/KillTeam2021';
+import {Archetype, FireteamArchetypes, Ploy} from '../../../types/KillTeam2021';
+
+const fireteamArchetypeMap: FireteamArchetypes = {
+  "Troupe Kill Team": [Archetype.SEEK_AND_DESTROY, Archetype.INFILTRATION, Archetype.RECON],
+}
 
 const strategicPloys: Ploy[] = [
   {
@@ -48,6 +52,6 @@ const tacticalPloys: Ploy[] = [
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap: null, tacOps: null }
+const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap, tacOps: null }
 
 export default data

--- a/src/components/KillTeam2021/data/troupe.ts
+++ b/src/components/KillTeam2021/data/troupe.ts
@@ -48,6 +48,6 @@ const tacticalPloys: Ploy[] = [
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, tacOps: null }
+const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap: null, tacOps: null }
 
 export default data

--- a/src/components/KillTeam2021/data/veteranGuardsmen.ts
+++ b/src/components/KillTeam2021/data/veteranGuardsmen.ts
@@ -1,4 +1,8 @@
-import { Ploy, TacOp } from '../../../types/KillTeam2021';
+import {Archetype, FireteamArchetypes, Ploy, TacOp} from '../../../types/KillTeam2021';
+
+const fireteamArchetypeMap: FireteamArchetypes = {
+  "Veteran Guardsman Kill Team": [Archetype.SECURITY],
+}
 
 const strategicPloys: Ploy[] = [
   {
@@ -77,6 +81,6 @@ const tacOps: TacOp[] = [{
   ]
 }]
 
-const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap: null, tacOps }
+const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap, tacOps }
 
 export default data

--- a/src/components/KillTeam2021/data/veteranGuardsmen.ts
+++ b/src/components/KillTeam2021/data/veteranGuardsmen.ts
@@ -77,6 +77,6 @@ const tacOps: TacOp[] = [{
   ]
 }]
 
-const data = { strategicPloys, tacticalPloys, tacOps }
+const data = { strategicPloys, tacticalPloys, fireteamArchetypeMap: null, tacOps }
 
 export default data

--- a/src/parsers/KillTeam2021/BattlescribeParser.ts
+++ b/src/parsers/KillTeam2021/BattlescribeParser.ts
@@ -129,6 +129,9 @@ export const parseBattlescribeXML = (doc : Document) : Roster => {
   for (const model of xpSelect('//bs:selection[@type=\'model\']', doc) as Element[]) {
     operatives.push(parseOperative(model))
   }
+
+  const fireteams = (xpSelect('//bs:force/@name', doc) as Node[]).map( (node) => { return node.nodeValue}) as string[]
+
   const psychicPowers = (xpSelect(".//bs:profile[@typeName='Psychic Power']", doc) as Node[]).map(parsePsychicPower)
   // Assign unique operative names if they don't have them
   const romanNumerals = [
@@ -151,6 +154,7 @@ export const parseBattlescribeXML = (doc : Document) : Roster => {
     name,
     faction,
     operatives,
-    psychicPowers
+    psychicPowers,
+    fireteams
   }
 }

--- a/src/types/KillTeam2021.ts
+++ b/src/types/KillTeam2021.ts
@@ -92,4 +92,16 @@ export type Roster = {
   faction: string,
   operatives: Operative[],
   psychicPowers: PsychicPower[],
+  fireteams: string[]
 };
+
+export enum Archetype {
+  SEEK_AND_DESTROY = "SEEK AND DESTROY",
+  SECURITY = "SECURITY",
+  INFILTRATION = "INFILTRATION",
+  RECON = "RECON"
+}
+
+export type FireteamArchetypes = {
+  [key: string]: Archetype[]
+}


### PR DESCRIPTION
Added parsing of fire teams (Battlescribe 'force' entries).

Added Archetype to data types.

Added faction data for mapping fire team name to archetypes. 

Added code to invoke the mapping for a roster.

Re-arranged tac-ops display on roster to also show archetypes as pills.

