### PR TITLE
Add dev page for KillTeam21 data

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-bootstrap-slider": "^3.0.0",
     "react-dom": "^16.13.1",
     "react-dropzone": "^11.4.2",
+    "react-router-dom": "^5.3.0",
     "react-string-replace": "^0.4.4",
     "typescript": "^4.4.3",
     "uuid": "^8.3.2",
@@ -55,6 +56,7 @@
   },
   "homepage": "https://dataslate.rocks",
   "devDependencies": {
+    "@types/react-router-dom": "^5.3.0",
     "@types/react-test-renderer": "^17.0.1",
     "@types/uuid": "^8.3.1",
     "@types/xmldom": "^0.1.31",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,8 @@ import { Container } from 'react-bootstrap'
 import { loadFiles } from './FileLoader'
 import { Roster as Roster2018 } from './types/KillTeam2018'
 import { Roster as Roster2021 } from './types/KillTeam2021'
+import { DataDevPage } from './components/KillTeam2021/DataDevPage'
+import { BrowserRouter as Router, Switch, Route } from 'react-router-dom'
 
 export function App () {
   const [roster, setRoster] = useState<Roster2018|Roster2021|null>(null)
@@ -38,10 +40,21 @@ export function App () {
   const isRosterKT21 = (roster: any): roster is Roster2021 => (roster.system === 'KillTeam2021')
 
   return (
-    <Container fluid='lg'>
-      {roster === null ? <Homepage onUpload={handleUpload} /> : <></>}
-      {(roster != null) && isRosterKT18(roster) ? <RosterView2018 name={roster.name} models={roster.models} onClose={handleClose} forceRules={roster.forceRules} onSelectionChanged={handleSelectionChanged} /> : <></>}
-      {(roster != null) && isRosterKT21(roster) ? <RosterView2021 name={roster.name} operatives={roster.operatives} psychicPowers={roster.psychicPowers} faction={roster.faction} fireteams={roster.fireteams} onClose={handleClose} /> : <></>}
-    </Container>
+    <Router>
+      <Switch>
+        <Route path='/kill_team_21/dev'>
+          <Container fluid='lg'>
+            <DataDevPage />
+          </Container>
+        </Route>
+        <Route path='/'>
+          <Container fluid='lg'>
+            {roster === null ? <Homepage onUpload={handleUpload} /> : <></>}
+            {(roster != null) && isRosterKT18(roster) ? <RosterView2018 name={roster.name} models={roster.models} onClose={handleClose} forceRules={roster.forceRules} onSelectionChanged={handleSelectionChanged} /> : <></>}
+            {(roster != null) && isRosterKT21(roster) ? <RosterView2021 name={roster.name} operatives={roster.operatives} psychicPowers={roster.psychicPowers} faction={roster.faction} fireteams={roster.fireteams} onClose={handleClose} /> : <></>}
+          </Container>
+        </Route>
+      </Switch>
+    </Router>
   )
 }

--- a/src/components/KillTeam2021/DataDevPage.tsx
+++ b/src/components/KillTeam2021/DataDevPage.tsx
@@ -1,0 +1,44 @@
+import React, { FC, useState } from 'react'
+import getFactionSpecificData from './data'
+import { FactionSpecificData } from './FactionSpecificData'
+
+import { data } from './data/index'
+
+const factionNames = data.map(faction => faction.name)
+
+export const DataDevPage: FC = () => {
+  const [faction, setFaction] = useState<string | null>(null)
+
+  const Content: FC = () => {
+    if (faction === null) {
+      return <></>
+    }
+
+    const factionArchetypesMap = getFactionSpecificData(faction)?.archetypes
+
+    if (factionArchetypesMap === undefined) {
+      return <></>
+    }
+
+    const factionFireteams = Object.keys(factionArchetypesMap)
+
+    return <FactionSpecificData faction={faction} fireteams={factionFireteams} />
+  }
+
+  return (
+    <>
+      <h1>
+        DEV PAGE
+      </h1>
+      <div style={{ marginBottom: '10px' }}>
+        <select onChange={e => setFaction(e.target.value)}>
+          <option />
+          {factionNames.map((faction, index) => <option value={faction} key={index}>{faction}</option>)}
+        </select>
+      </div>
+      <div>
+        <Content />
+      </div>
+    </>
+  )
+}

--- a/src/components/KillTeam2021/FactionSpecificData.tsx
+++ b/src/components/KillTeam2021/FactionSpecificData.tsx
@@ -1,0 +1,64 @@
+import React, { FC } from 'react'
+import { Card } from 'react-bootstrap'
+import { Archetype } from '../../types/KillTeam2021'
+import { PloysColumn } from './PloysColumn'
+import { TacOpsList } from './TacOpsList'
+import getFactionSpecificData from './data'
+import { ArchetypeBadge } from './ArchetypeBadge'
+
+interface Props {
+  faction: string
+  fireteams: string[]
+}
+
+export const FactionSpecificData: FC<Props> = (props) => {
+  const headingStyle = {
+    background: '#FF6F2D',
+    color: 'black',
+    padding: '10px',
+    width: '100%',
+    display: 'flex'
+  }
+
+  const factionSpecificData = getFactionSpecificData(props.faction)
+
+  const archetypes: Archetype[] = props.fireteams
+    .flatMap(fireteam => factionSpecificData?.archetypes[fireteam] as unknown as Archetype)
+    .filter(Boolean)
+    .filter((item, index, self) => self.indexOf(item) === index)
+
+  // @ts-expect-error
+  const tacOps = factionSpecificData?.tacOps
+
+  return (
+    <>
+      {(factionSpecificData != null) &&
+        <div>
+          <div style={{ display: 'flex', justifyContent: 'space-between', flexDirection: 'row' }}>
+            <Card style={{ width: '100%', marginRight: '5px' }}>
+              <Card.Header style={{ ...headingStyle }} as='h2'>Strategic Ploys</Card.Header>
+              <Card.Body>
+                <PloysColumn ploys={factionSpecificData.strategicPloys} />
+              </Card.Body>
+            </Card>
+            <Card style={{ width: '100%', marginLeft: '5px' }}>
+              <Card.Header style={{ ...headingStyle }} as='h2'>Tactical Ploys</Card.Header>
+              <Card.Body>
+                <PloysColumn ploys={factionSpecificData.tacticalPloys} />
+              </Card.Body>
+            </Card>
+          </div>
+          <div>
+            <Card>
+              <Card.Header style={{ ...headingStyle }} as='h2'>Tac Ops</Card.Header>
+              <Card.Body>
+                <Card.Title>ARCHETYPES - {archetypes.map((archetype, index) => { return <ArchetypeBadge key={index} archetype={archetype} /> })}</Card.Title>
+
+                {tacOps !== undefined && <TacOpsList tacOps={tacOps} />}
+              </Card.Body>
+            </Card>
+          </div>
+        </div>}
+    </>
+  )
+}

--- a/src/components/KillTeam2021/Roster.tsx
+++ b/src/components/KillTeam2021/Roster.tsx
@@ -1,16 +1,13 @@
 import React, { MouseEvent } from 'react'
 import { Col, Card } from 'react-bootstrap'
 import { CloseButton } from '../CloseButton'
-import { Operative, Datacard, PsychicPower, Archetype } from '../../types/KillTeam2021'
+import { Operative, Datacard, PsychicPower } from '../../types/KillTeam2021'
 import { Datasheet } from './Datasheet'
 import { RuleList } from './RuleList'
 import { PowerList } from './PowerList'
-import { PloysColumn } from './PloysColumn'
-import { TacOpsList } from './TacOpsList'
 import hash from 'node-object-hash'
 import _ from 'lodash'
-import getFactionSpecificData from './data'
-import { ArchetypeBadge } from './ArchetypeBadge'
+import { FactionSpecificData } from './FactionSpecificData'
 
 interface Props {
   name: string
@@ -39,15 +36,6 @@ export function Roster (props: Props) {
     display: 'flex'
   }
   const datacards = groupByDatacard(props.operatives)
-  const factionSpecificData = getFactionSpecificData(props.faction)
-
-  let archetypes: Archetype[] = props.fireteams.flatMap((fireteam) => {
-    return factionSpecificData?.archetypes[fireteam] as Archetype[] ?? null
-  }).filter(item => (item !== null))
-
-  // Now remove duplicates
-  archetypes = (archetypes.filter((item, index) => archetypes.indexOf(item) === index))
-  console.log(archetypes)
 
   return (
     <>
@@ -75,34 +63,7 @@ export function Roster (props: Props) {
         </Card.Body>
       </Card>}
 
-      {(factionSpecificData != null) &&
-        <div>
-          <div style={{ display: 'flex', justifyContent: 'space-between', flexDirection: 'row' }}>
-            <Card style={{ width: '100%', marginRight: '5px' }}>
-              <Card.Header style={{ ...headingStyle }} as='h2'>Strategic Ploys</Card.Header>
-              <Card.Body>
-                <PloysColumn ploys={factionSpecificData.strategicPloys} />
-              </Card.Body>
-            </Card>
-            <Card style={{ width: '100%', marginLeft: '5px' }}>
-              <Card.Header style={{ ...headingStyle }} as='h2'>Tactical Ploys</Card.Header>
-              <Card.Body>
-                <PloysColumn ploys={factionSpecificData.tacticalPloys} />
-              </Card.Body>
-            </Card>
-          </div>
-
-        </div>}
-      {(((factionSpecificData != null) && factionSpecificData.tacOps) || (archetypes.length > 0)) &&
-        <Card>
-          <Card.Header style={{ ...headingStyle }} as='h2'>Tac Ops</Card.Header>
-          <Card.Body>
-            {archetypes.length > 0 &&
-              <Card.Title>ARCHETYPES - {archetypes.map(archetype => { return <ArchetypeBadge archetype={archetype} /> })}</Card.Title>}
-
-            {(factionSpecificData != null) && factionSpecificData.tacOps && <TacOpsList tacOps={factionSpecificData.tacOps} />}
-          </Card.Body>
-        </Card>}
+      <FactionSpecificData faction={props.faction} fireteams={props.fireteams} />
     </>
   )
 }

--- a/src/components/KillTeam2021/data/broodCoven.ts
+++ b/src/components/KillTeam2021/data/broodCoven.ts
@@ -47,6 +47,11 @@ const tacticalPloys: Ploy[] = [
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, archetypes, tacOps: null }
+const data = {
+  name: 'Brood Coven' as const,
+  strategicPloys,
+  tacticalPloys,
+  archetypes
+}
 
 export default data

--- a/src/components/KillTeam2021/data/cadreMercenary.ts
+++ b/src/components/KillTeam2021/data/cadreMercenary.ts
@@ -46,6 +46,11 @@ const tacticalPloys: Ploy[] = [
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, archetypes, tacOps: null }
+const data = {
+  name: 'Cadre Mercenary' as const,
+  strategicPloys,
+  tacticalPloys,
+  archetypes
+}
 
 export default data

--- a/src/components/KillTeam2021/data/chaosDaemons.ts
+++ b/src/components/KillTeam2021/data/chaosDaemons.ts
@@ -47,12 +47,17 @@ const tacticalPloys: Ploy[] = [
       'Before that PINK HORROR operative is removed from the killzone, set up two BLUE HORROR operatives as close as possible to that operative and not within Engagement Range of enemy operatives',
       `Before that BLUE HORROR operative is removed from the killzone, set up one BRIMESTONE HORRORS operative as close as possible to that operative and not within Engagement Range of enemy
        operatives.`
-     ],
+    ],
     postOptionText: `In either case, set up those operatives with the same order as the previous operative (including if it was ready or activated). In narrative play, any operatives set up as a
                       result of this Tactical Ploy are no longer part of your kill team after the game.`
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, archetypes, tacOps: null }
+const data = {
+  name: 'Chaos Daemons' as const,
+  strategicPloys,
+  tacticalPloys,
+  archetypes
+}
 
 export default data

--- a/src/components/KillTeam2021/data/commorrite.ts
+++ b/src/components/KillTeam2021/data/commorrite.ts
@@ -16,10 +16,10 @@ const strategicPloys: Ploy[] = [
     description: `Until the end of the Turning Point, each time a friendly WYCH operative fights in combat, in the Resolve Successful Hits step of that combat, each time your opponent strikes
                   with a normal hit, you can roll one D6: on a 4+, treat that strike as a parry instead. In addition, each time a friendly WYCH operative performs any kind of move:`,
     options: [
-        `It can move around, across and over other operatives (and their bases) as if they were not there, but must finish the move following all requirements specified by that move, and 
+      `It can move around, across and over other operatives (and their bases) as if they were not there, but must finish the move following all requirements specified by that move, and
         cannot finish its move on top of other operatives (or their bases).`,
-        'It can ignore the first ⬤ distance it travels when climbing, traversing and dropping.',
-        'It automatically passes jump tests.'
+      'It can ignore the first ⬤ distance it travels when climbing, traversing and dropping.',
+      'It automatically passes jump tests.'
     ]
   }, {
     name: 'Prey On The Weak',
@@ -29,7 +29,7 @@ const strategicPloys: Ploy[] = [
   }, {
     name: 'Inured to Suffering',
     cost: 1,
-    description: `Until the end of the Turning Point, each time a friendly COMMORRITE💀 operative would lose a wound, roll one D6: on a 6+, that wound is not lost. You can only use this 
+    description: `Until the end of the Turning Point, each time a friendly COMMORRITE💀 operative would lose a wound, roll one D6: on a 6+, that wound is not lost. You can only use this
                   Strategic Ploy if one or more operatives have been incapacitated.`
   }
 ]
@@ -54,6 +54,11 @@ const tacticalPloys: Ploy[] = [
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, archetypes, tacOps: null }
+const data = {
+  name: 'Commorrite' as const,
+  strategicPloys,
+  tacticalPloys,
+  archetypes
+}
 
 export default data

--- a/src/components/KillTeam2021/data/craftworld.ts
+++ b/src/components/KillTeam2021/data/craftworld.ts
@@ -46,6 +46,11 @@ const tacticalPloys: Ploy[] = [
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, archetypes, tacOps: null }
+const data = {
+  name: 'Craftworld' as const,
+  strategicPloys,
+  tacticalPloys,
+  archetypes
+}
 
 export default data

--- a/src/components/KillTeam2021/data/deathGuard.ts
+++ b/src/components/KillTeam2021/data/deathGuard.ts
@@ -49,6 +49,11 @@ const tacticalPloys: Ploy[] = [
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, archetypes, tacOps: null }
+const data = {
+  name: 'Death Guard' as const,
+  strategicPloys,
+  tacticalPloys,
+  archetypes
+}
 
 export default data

--- a/src/components/KillTeam2021/data/ecclesiarchy.ts
+++ b/src/components/KillTeam2021/data/ecclesiarchy.ts
@@ -49,6 +49,11 @@ const tacticalPloys: Ploy[] = [
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, archetypes, tacOps: null }
+const data = {
+  name: 'Ecclesiarchy' as const,
+  strategicPloys,
+  tacticalPloys,
+  archetypes
+}
 
 export default data

--- a/src/components/KillTeam2021/data/forgeWorld.ts
+++ b/src/components/KillTeam2021/data/forgeWorld.ts
@@ -61,6 +61,11 @@ const tacticalPloys: Ploy[] = [
 
 ]
 
-const data = { strategicPloys, tacticalPloys, archetypes, tacOps: null }
+const data = {
+  name: 'Forge World' as const,
+  strategicPloys,
+  tacticalPloys,
+  archetypes
+}
 
 export default data

--- a/src/components/KillTeam2021/data/greenskin.ts
+++ b/src/components/KillTeam2021/data/greenskin.ts
@@ -42,6 +42,11 @@ const tacticalPloys: Ploy[] = [
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, archetypes, tacOps: null }
+const data = {
+  name: 'Greenskin' as const,
+  strategicPloys,
+  tacticalPloys,
+  archetypes
+}
 
 export default data

--- a/src/components/KillTeam2021/data/greyKnights.ts
+++ b/src/components/KillTeam2021/data/greyKnights.ts
@@ -8,18 +8,18 @@ const strategicPloys: Ploy[] = [
   {
     name: 'Bolter Discipline',
     cost: 1,
-    description: `Until the end of the Turning Point, each time a friendly GREY KNIGHT💀 operative is activated, if it does not perform a Fight action during that activation, it 
+    description: `Until the end of the Turning Point, each time a friendly GREY KNIGHT💀 operative is activated, if it does not perform a Fight action during that activation, it
                   can perform two Shoot actions during that activation if a storm bolter is selected for each of those shooting attacks`
   }, {
     name: 'Shock Assault',
     cost: 1,
-    description: `Until the end of the Turning Point, each time a friendly GREY KNIGHT💀 operative is activated, if it does not perform a Shoot action during that activation, it 
+    description: `Until the end of the Turning Point, each time a friendly GREY KNIGHT💀 operative is activated, if it does not perform a Shoot action during that activation, it
                   can perform two Fight actions during that activation`
   }, {
     name: 'Tide of Shadows',
     cost: 1,
     description: `Until the end of the Turning Point, each time an enemy operative on a Vantage Point makes a shooting attack, each friendly GREY KNIGHT💀 operative that has a Conceal
-                  order, is in Cover provided by Light terrain and is more than ⬟ from that enemy operative cannot be treated as being on an Engage order for that shooting attack as 
+                  order, is in Cover provided by Light terrain and is more than ⬟ from that enemy operative cannot be treated as being on an Engage order for that shooting attack as
                   a result of that Vantage Point.`
   }, {
     name: 'Tide of Celerity',
@@ -37,12 +37,17 @@ const tacticalPloys: Ploy[] = [
   }, {
     name: 'And they shall know no fear',
     cost: 1,
-    description: `Use this Tactical Ploy when a friendly GREY KNIGHT💀 operative is activated. Until the end of that operative's activation, you can ignore any or all modifiers to 
+    description: `Use this Tactical Ploy when a friendly GREY KNIGHT💀 operative is activated. Until the end of that operative's activation, you can ignore any or all modifiers to
                 its APL characteristic and it is not injured.`
   }
 
 ]
 
-const data = { strategicPloys, tacticalPloys, archetypes, tacOps: null }
+const data = {
+  name: 'Grey Knight' as const,
+  strategicPloys,
+  tacticalPloys,
+  archetypes
+}
 
 export default data

--- a/src/components/KillTeam2021/data/hiveFleet.ts
+++ b/src/components/KillTeam2021/data/hiveFleet.ts
@@ -39,6 +39,11 @@ const tacticalPloys: Ploy[] = [
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, archetypes, tacOps: null }
+const data = {
+  name: 'Hive Fleet' as const,
+  strategicPloys,
+  tacticalPloys,
+  archetypes
+}
 
 export default data

--- a/src/components/KillTeam2021/data/hunterCadre.ts
+++ b/src/components/KillTeam2021/data/hunterCadre.ts
@@ -10,7 +10,7 @@ const strategicPloys: Ploy[] = [
   {
     name: 'Aimed Pulse Volley',
     cost: 1,
-    description: `Until the end of the Turning Point, each time a friendly FIRE WARRIOR operative makes a shooting attack with a pulse rifle as a result of a Shoot action, in the 
+    description: `Until the end of the Turning Point, each time a friendly FIRE WARRIOR operative makes a shooting attack with a pulse rifle as a result of a Shoot action, in the
                   Roll Attack Dice step of that shooting attack, if it has not moved during that activation, you can re-roll one of your attack dice.`
   }, {
     name: 'Breach and Clear',
@@ -32,7 +32,7 @@ const strategicPloys: Ploy[] = [
   }, {
     name: 'Recon Sweep',
     cost: 1,
-    description: `Friendly PATHFINDER operatives that are wholly within ⬟ of any killzone edge can immediately perform a free Dash action, but only if they can finish that move 
+    description: `Friendly PATHFINDER operatives that are wholly within ⬟ of any killzone edge can immediately perform a free Dash action, but only if they can finish that move
                   wholly within ⬟ of a killzone edge that is not your own killzone edge.`
   }
 ]
@@ -43,7 +43,7 @@ const tacticalPloys: Ploy[] = [
     cost: 1,
     description: `Use this Tactical Ploy in the Firefight phase, when a Shoot action is declared for a friendly HUNTER CADRE💀 operative.In the Select Valid Target step of that
                   shooting attack, you must select an enemy operative that is within Engagement Range of one or more other friendly operatives and within ⬟ of the active operative,
-                  and that enemy operative cannot be in Cover as a result of friendly operative's bases. Note, however that in the Roll Defence Dice step of that shooting attack, 
+                  and that enemy operative cannot be in Cover as a result of friendly operative's bases. Note, however that in the Roll Defence Dice step of that shooting attack,
                   the enemy operative can be in Cover as a result of friendly operatives' bases.`
   }, {
     name: 'Stand and Fire',
@@ -57,6 +57,11 @@ const tacticalPloys: Ploy[] = [
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, archetypes, tacOps: null }
+const data = {
+  name: 'Hunter Cadre' as const,
+  strategicPloys,
+  tacticalPloys,
+  archetypes
+}
 
 export default data

--- a/src/components/KillTeam2021/data/hunterClade.ts
+++ b/src/components/KillTeam2021/data/hunterClade.ts
@@ -12,9 +12,9 @@ const strategicPloys: Ploy[] = [
     cost: 1,
     description: 'Until the end of the Turning Point:',
     options: [
-        `Each time a friendly HUNTER CLADE💀 VANGUARD operative that is within ⬤ of an objective marker or within ⬟ of your opponent's drop zone make a shooting attack,
+      `Each time a friendly HUNTER CLADE💀 VANGUARD operative that is within ⬤ of an objective marker or within ⬟ of your opponent's drop zone make a shooting attack,
         in the Roll Attack Dice step of that shooting attack, you can re-roll one of your attack dice.`,
-        `Each time a friendly HUNTER CLADE💀 RANGER operative that has not moved during the Turning Point makes a shooting attack, in the Roll Attack Dice step of that shooting 
+      `Each time a friendly HUNTER CLADE💀 RANGER operative that has not moved during the Turning Point makes a shooting attack, in the Roll Attack Dice step of that shooting
         attack, you can re-roll one of your attack dice.`
     ]
   }, {
@@ -46,7 +46,7 @@ const tacticalPloys: Ploy[] = [
     description: 'Use this Tactical Ploy in the Scouting step of the mission sequence, when you resolve your scouting option.',
     options: [
       'If you selected the Recon option, you can also perform a free Dash action with up to two friendly HUNTER CLADE💀 RANGER operatives that are wholly within your drop zone',
-        `If you selected the Infiltrate option, during the first Turning Point, you can also change the order of up to two ready friendly HUNTER CLADE💀 RANGER operatives when
+      `If you selected the Infiltrate option, during the first Turning Point, you can also change the order of up to two ready friendly HUNTER CLADE💀 RANGER operatives when
          each of them are activated`
     ]
   }, {
@@ -57,7 +57,7 @@ const tacticalPloys: Ploy[] = [
   }, {
     name: 'Concealed Position',
     cost: 1,
-    description: `Use this Tactical Ploy in the Set Up Operatives step of the mission sequence. Select one friendly HUNTER CLADE💀 INFILTRATOR operative. That operative can be 
+    description: `Use this Tactical Ploy in the Set Up Operatives step of the mission sequence. Select one friendly HUNTER CLADE💀 INFILTRATOR operative. That operative can be
                   set up with a Conceal order anywhere in the killzone that is within ▲ of Heavy terrain and more than ⬟ from enemy operatives and the enemy drop zone. That
                   operative cannot have its order changed during the first Turning Point as a result of the Infiltrate option in the Scouting step. You can only use this Tactical
                   Ploy once.`
@@ -84,7 +84,7 @@ const tacOps: TacOp[] = [
     description: [
       `At the end of any Turning Point, if an Imperative is active for your kill team, and the total wounds lost by enemy operatives during that Turning Point is greater than
       that lost by friendly operatives, you score 1VP`,
-      `At the end of any Turning Point, if a different Imperative is active for your kill team, and the total wounds lost by enemy operatives during that Turning Point is 
+      `At the end of any Turning Point, if a different Imperative is active for your kill team, and the total wounds lost by enemy operatives during that Turning Point is
       greater than that lost by friendly operatives, you score 1VP`
     ]
   }, {
@@ -98,6 +98,12 @@ const tacOps: TacOp[] = [
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, archetypes, tacOps }
+const data = {
+  name: 'Hunter Clade' as const,
+  strategicPloys,
+  tacticalPloys,
+  archetypes,
+  tacOps
+}
 
 export default data

--- a/src/components/KillTeam2021/data/imperialGuard.ts
+++ b/src/components/KillTeam2021/data/imperialGuard.ts
@@ -39,12 +39,17 @@ const tacticalPloys: Ploy[] = [
     name: 'Bring It Down!',
     cost: 1,
     description: `Use this Tactical Ploy after a friendly IMPERIAL GUARD💀 operative makes a shooting attack. Until the end of the Turning Point, each time another friendly IMPERIAL GUARD💀
-                  operative makes a shooting attack against the target of that shooting attack, in the Roll Attack Dice step of that subsequent shooting attack, you can re-roll any or all 
+                  operative makes a shooting attack against the target of that shooting attack, in the Roll Attack Dice step of that subsequent shooting attack, you can re-roll any or all
                   of your attack dice.`
   }
 
 ]
 
-const data = { strategicPloys, tacticalPloys, archetypes, tacOps: null }
+const data = {
+  name: 'Imperial Guard' as const,
+  strategicPloys,
+  tacticalPloys,
+  archetypes
+}
 
 export default data

--- a/src/components/KillTeam2021/data/index.ts
+++ b/src/components/KillTeam2021/data/index.ts
@@ -1,73 +1,50 @@
 import broodCoven from './broodCoven'
-import hiveFleet from './hiveFleet'
-import kommando from './kommando'
-import veteranGuardsmen from './veteranGuardsmen'
-import spaceMarine from './spaceMarine'
-import greyKnights from './greyKnights'
-import imperialGuard from './imperialGuard'
-import forgeWorld from './forgeWorld'
-import ecclesiarchy from './ecclesiarchy'
-import talonsOfTheEmporer from './talonsOfTheEmporer'
-import traitorSpaceMarine from './traitorSpaceMarine'
+import cadreMercenary from './cadreMercenary'
+import chaosDaemon from './chaosDaemons'
+import commorite from './commorrite'
+import craftworld from './craftworld'
 import deathGuard from './deathGuard'
-import thousandSons from './thousandSons'
+import ecclesiarchy from './ecclesiarchy'
+import forgeWorld from './forgeWorld'
+import greenskin from './greenskin'
+import greyKnights from './greyKnights'
+import hiveFleet from './hiveFleet'
 import hunterCadre from './hunterCadre'
 import hunterClade from './hunterClade'
-import cadreMercenary from './cadreMercenary'
-import greenskin from './greenskin'
+import imperialGuard from './imperialGuard'
+import kommando from './kommando'
+import spaceMarine from './spaceMarine'
+import talonsOfTheEmporer from './talonsOfTheEmporer'
+import thousandSons from './thousandSons'
+import traitorSpaceMarine from './traitorSpaceMarine'
 import troupe from './troupe'
-import craftworld from './craftworld'
-import commorite from './commorite'
-import chaosDaemon from './chaosDaemon'
+import veteranGuardsmen from './veteranGuardsmen'
 
-const getFactionSpecificData = (factionName: string) => {
-  switch (factionName) {
-    case 'Veteran Guardsmen':
-      return veteranGuardsmen
-    case 'Kommando':
-      return kommando
-    case 'Brood Coven':
-      return broodCoven
-    case 'Hive Fleet':
-      return hiveFleet
-    case 'Space Marine':
-      return spaceMarine
-    case 'Grey Knight':
-      return greyKnights
-    case 'Imperial Guard':
-      return imperialGuard
-    case 'Forge World':
-      return forgeWorld
-    case 'Ecclesiarchy':
-      return ecclesiarchy
-    case 'Talons of the Emperor':
-      return talonsOfTheEmporer
-    case 'Traitor Space Marine':
-      return traitorSpaceMarine
-    case 'Death Guard':
-      return deathGuard
-    case 'Thousand Sons':
-      return thousandSons
-    case 'Hunter Cadre':
-      return hunterCadre
-    case 'Hunter Clade':
-      return hunterClade
-    case 'Cadre Mercenary':
-      return cadreMercenary
-    case 'Greenskin':
-      return greenskin
-    case 'Troupe':
-      return troupe
-    case 'Craftworld':
-      return craftworld
-    case 'Commorrite':
-      return commorite
-    case 'Chaos Daemon':
-    case 'Chaos Daemons': // Battlescribe data has the 's', compendium has no 's'
-      return chaosDaemon
-    default:
-      return null
-  }
-}
+const data = [
+  broodCoven,
+  cadreMercenary,
+  chaosDaemon,
+  commorite,
+  craftworld,
+  deathGuard,
+  ecclesiarchy,
+  forgeWorld,
+  greenskin,
+  greyKnights,
+  hiveFleet,
+  hunterCadre,
+  hunterClade,
+  imperialGuard,
+  kommando,
+  spaceMarine,
+  talonsOfTheEmporer,
+  thousandSons,
+  traitorSpaceMarine,
+  troupe,
+  veteranGuardsmen
+]
+
+const getFactionSpecificData = (factionName: string) => data.find(factionData => factionData.name === factionName)
 
 export default getFactionSpecificData
+export { data }

--- a/src/components/KillTeam2021/data/kommando.ts
+++ b/src/components/KillTeam2021/data/kommando.ts
@@ -78,6 +78,12 @@ const tacOps: TacOp[] = [
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, archetypes, tacOps }
+const data = {
+  name: 'Kommando' as const,
+  strategicPloys,
+  tacticalPloys,
+  archetypes,
+  tacOps
+}
 
 export default data

--- a/src/components/KillTeam2021/data/spaceMarine.ts
+++ b/src/components/KillTeam2021/data/spaceMarine.ts
@@ -16,19 +16,19 @@ const strategicPloys: Ploy[] = [
   {
     name: 'Bolter Discipline',
     cost: 1,
-    description: `Until the end of the Turning Point, each time a friendly SPACE MARINE💀 operative (excluding a SCOUT operative) is activated, if it does not perform a Fight action 
-                  during that activation, it can perform two Shoot actions during that activation if a bolt weapon is selected for each of those shooting attacks. A bolt weapon is a 
-                  ranged weapon that includes 'bolt' in its name, e.g. boltgun, heavy bolter etc. In the case of the infernus heavy bolter, it must be the heavy bolter profile that 
+    description: `Until the end of the Turning Point, each time a friendly SPACE MARINE💀 operative (excluding a SCOUT operative) is activated, if it does not perform a Fight action
+                  during that activation, it can perform two Shoot actions during that activation if a bolt weapon is selected for each of those shooting attacks. A bolt weapon is a
+                  ranged weapon that includes 'bolt' in its name, e.g. boltgun, heavy bolter etc. In the case of the infernus heavy bolter, it must be the heavy bolter profile that
                   is selected.`
   }, {
     name: 'Shock Assault',
     cost: 1,
-    description: `Until the end of the Turning Point, each time a friendly SPACE MARINE💀 operative (excluding a SCOUT operative) is activated, if it does not perform a Shoot action 
+    description: `Until the end of the Turning Point, each time a friendly SPACE MARINE💀 operative (excluding a SCOUT operative) is activated, if it does not perform a Shoot action
                   during that activation, it can perform two Fight actions during that activation.`
   }, {
     name: 'Tactical Precision',
     cost: 1,
-    description: `Until the end of the Turning Point, while a friendly SPACE MARINE💀 operative is within ■ of and Visible to a friendly LEADER operative, each time it fights in combat 
+    description: `Until the end of the Turning Point, while a friendly SPACE MARINE💀 operative is within ■ of and Visible to a friendly LEADER operative, each time it fights in combat
                   or makes a shooting attack, in the Roll Attack Dice step of that combat or shooting attack, you can re-roll one of your attack dice.`
   }
 ]
@@ -37,7 +37,7 @@ const tacticalPloys: Ploy[] = [
   {
     name: 'Transhuman Physiology',
     cost: 1,
-    description: `Use this Tactical Ploy in the Roll Defence Dice step of a shooting attack, after rolling defence dice for a friendly PRIMARIS operative. You can change one of your 
+    description: `Use this Tactical Ploy in the Roll Defence Dice step of a shooting attack, after rolling defence dice for a friendly PRIMARIS operative. You can change one of your
                   retained normal saves to a critical save.`
   }, {
     name: 'Only in death does duty end',
@@ -47,12 +47,12 @@ const tacticalPloys: Ploy[] = [
   }, {
     name: 'And they shall know no fear',
     cost: 1,
-    description: `Use this Tactical Ploy when a friendly SPACE MARINE💀 operative is activated. Until the end of that operative's activation, you can ignore any or all modifiers to 
+    description: `Use this Tactical Ploy when a friendly SPACE MARINE💀 operative is activated. Until the end of that operative's activation, you can ignore any or all modifiers to
                 its APL characteristic and it is not injured.`
   }, {
     name: 'Omni-Scrambler',
     cost: 1,
-    description: `Use this Tactical Ploy at the start of the Firefight phase. Select one enemy operative Visible to and within ⬟ of a friendly INFILTRATOR operative. Until the end 
+    description: `Use this Tactical Ploy at the start of the Firefight phase. Select one enemy operative Visible to and within ⬟ of a friendly INFILTRATOR operative. Until the end
                   of the Turning Point that enemy operative cannot be activated until another enemy operative has been activated (unless it is the only remaining enemy operative).`
   }, {
     name: 'Multi-Spectrum Array',
@@ -63,14 +63,19 @@ const tacticalPloys: Ploy[] = [
     cost: 1,
     description: 'Use this Tactical Ploy during a friendly REIVER operative\'s activation. Until the start of the next Turning Point:',
     options: [
-        `Each time an enemy operative would perform a mission action or the Pick Up action, if this friendly REIVER operative is within SQUARE of that enemy operative, one additional
+      `Each time an enemy operative would perform a mission action or the Pick Up action, if this friendly REIVER operative is within SQUARE of that enemy operative, one additional
         action point must be subtracted to perform that action.`,
-        'When determining control of an objective marker that friendly REIVER operative is within range of, treat enemy operatives\' total APL as being 1 less. Note that this is not a modifier.'
+      'When determining control of an objective marker that friendly REIVER operative is within range of, treat enemy operatives\' total APL as being 1 less. Note that this is not a modifier.'
     ]
   }
 
 ]
 
-const data = { strategicPloys, tacticalPloys, archetypes, tacOps: null }
+const data = {
+  name: 'Space Marine' as const,
+  strategicPloys,
+  tacticalPloys,
+  archetypes
+}
 
 export default data

--- a/src/components/KillTeam2021/data/talonsOfTheEmporer.ts
+++ b/src/components/KillTeam2021/data/talonsOfTheEmporer.ts
@@ -14,7 +14,7 @@ const strategicPloys: Ploy[] = [
   }, {
     name: 'Creeping Dread',
     cost: 1,
-    description: `Until the end of the Turning Point, while an enemy operative is within ■ of a friendly ANATHEMA PSYKANA operative, worsen the Ballistic Skill and Weapon Skill 
+    description: `Until the end of the Turning Point, while an enemy operative is within ■ of a friendly ANATHEMA PSYKANA operative, worsen the Ballistic Skill and Weapon Skill
                   characteristics of ranged and melee weapons respectively that enemy operative is equipped with as if it is injured.`
   }, {
     name: 'Peerless Warriors',
@@ -46,6 +46,11 @@ const tacticalPloys: Ploy[] = [
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, archetypes, tacOps: null }
+const data = {
+  name: 'Talons of the Emperor' as const,
+  strategicPloys,
+  tacticalPloys,
+  archetypes
+}
 
 export default data

--- a/src/components/KillTeam2021/data/thousandSons.ts
+++ b/src/components/KillTeam2021/data/thousandSons.ts
@@ -42,11 +42,16 @@ const tacticalPloys: Ploy[] = [
   }, {
     name: 'Infernal Fusillade',
     cost: 1,
-    description: `Use this Tactical Ploy after making a shooting attack with a friendly ARCANA ASTARTES operative (excluding an ASPIRING SORCERER operative) in which the target did 
+    description: `Use this Tactical Ploy after making a shooting attack with a friendly ARCANA ASTARTES operative (excluding an ASPIRING SORCERER operative) in which the target did
                   not lose any wounds. Repeat that shooting attack.`
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, archetypes, tacOps: null }
+const data = {
+  name: 'Thousand Sons' as const,
+  strategicPloys,
+  tacticalPloys,
+  archetypes
+}
 
 export default data

--- a/src/components/KillTeam2021/data/traitorSpaceMarine.ts
+++ b/src/components/KillTeam2021/data/traitorSpaceMarine.ts
@@ -41,11 +41,16 @@ const tacticalPloys: Ploy[] = [
   }, {
     name: 'Warp Infused',
     cost: 1,
-    description: `Use this Tactical Ploy when a friendly HERETIC ASTARTES operative is activated. Until the end of that operative's activation, you can ignore any or all modifiers to 
+    description: `Use this Tactical Ploy when a friendly HERETIC ASTARTES operative is activated. Until the end of that operative's activation, you can ignore any or all modifiers to
                   its APL characteristic and it is not injured.`
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, archetypes, tacOps: null }
+const data = {
+  name: 'Traitor Space Marine' as const,
+  strategicPloys,
+  tacticalPloys,
+  archetypes
+}
 
 export default data

--- a/src/components/KillTeam2021/data/troupe.ts
+++ b/src/components/KillTeam2021/data/troupe.ts
@@ -52,6 +52,11 @@ const tacticalPloys: Ploy[] = [
   }
 ]
 
-const data = { strategicPloys, tacticalPloys, archetypes, tacOps: null }
+const data = {
+  name: 'Troupe' as const,
+  strategicPloys,
+  tacticalPloys,
+  archetypes
+}
 
 export default data

--- a/src/components/KillTeam2021/data/veteranGuardsmen.ts
+++ b/src/components/KillTeam2021/data/veteranGuardsmen.ts
@@ -81,6 +81,12 @@ const tacOps: TacOp[] = [{
   ]
 }]
 
-const data = { strategicPloys, tacticalPloys, archetypes, tacOps }
+const data = {
+  name: 'Veteran Guardsmen' as const,
+  strategicPloys,
+  tacticalPloys,
+  archetypes,
+  tacOps
+}
 
 export default data

--- a/yarn.lock
+++ b/yarn.lock
@@ -1157,6 +1157,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.4.tgz#fd17d16bfdf878e6dd02d19753a39fa8a8d9c84a"
+  integrity sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.13.8", "@babel/runtime@^7.14.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
   version "7.14.8"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.8.tgz#7119a56f421018852694290b9f9148097391b446"
@@ -1835,6 +1842,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/history@*":
+  version "4.7.9"
+  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.9.tgz#1cfb6d60ef3822c589f18e70f8b12f9a28ce8724"
+  integrity sha512-MUc6zSmU3tEVnkQ78q0peeEjKWPUADMlC/t++2bI8WnAG2tvYRPIgHG8lWkXwqc8MsUF6Z2MOf+Mh5sazOmhiQ==
+
 "@types/html-minifier-terser@^5.0.0":
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.1.2.tgz#693b316ad323ea97eed6b38ed1a3cc02b1672b57"
@@ -1932,6 +1944,23 @@
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.9.tgz#441a981da9d7be117042e1a6fd3dac4b30f55add"
   integrity sha512-wIvGxLfgpVDSAMH5utdL9Ngm5Owu0VsGmldro3ORLXV8CShrL8awVj06NuEXFQ5xyaYfdca7Sgbk/50Ri1GdPg==
   dependencies:
+    "@types/react" "*"
+
+"@types/react-router-dom@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-5.3.0.tgz#8c4e0aa0ccaf638ba965829ad29a10ac3cbe2212"
+  integrity sha512-svUzpEpKDwK8nmfV2vpZNSsiijFNKY8+gUqGqvGGOVrXvX58k1JIJubZa5igkwacbq/0umphO5SsQn/BQsnKpw==
+  dependencies:
+    "@types/history" "*"
+    "@types/react" "*"
+    "@types/react-router" "*"
+
+"@types/react-router@*":
+  version "5.1.16"
+  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-5.1.16.tgz#f3ba045fb96634e38b21531c482f9aeb37608a99"
+  integrity sha512-8d7nR/fNSqlTFGHti0R3F9WwIertOaaA1UEB8/jr5l5mDMOs4CidEgvvYMw4ivqrBK+vtVLxyTj2P+Pr/dtgzg==
+  dependencies:
+    "@types/history" "*"
     "@types/react" "*"
 
 "@types/react-test-renderer@^17.0.1":
@@ -5997,6 +6026,18 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
+history@^4.9.0:
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
+  integrity sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    loose-envify "^1.2.0"
+    resolve-pathname "^3.0.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+    value-equal "^1.0.1"
+
 hmac-drbg@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -6006,7 +6047,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -6769,6 +6810,11 @@ is-wsl@^2.1.1, is-wsl@^2.2.0:
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
   dependencies:
     is-docker "^2.0.0"
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -7685,7 +7731,7 @@ loglevel@^1.6.8:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.7.1.tgz#005fde2f5e6e47068f935ff28573e125ef72f197"
   integrity sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -7913,6 +7959,14 @@ min-indent@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
+
+mini-create-react-context@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz#072171561bfdc922da08a60c2197a497cc2d1d5e"
+  integrity sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==
+  dependencies:
+    "@babel/runtime" "^7.12.1"
+    tiny-warning "^1.0.3"
 
 mini-css-extract-plugin@0.11.3:
   version "0.11.3"
@@ -8761,6 +8815,13 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
+
+path-to-regexp@^1.7.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
+  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^3.0.0:
   version "3.0.0"
@@ -9925,7 +9986,7 @@ react-error-overlay@^6.0.9:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
   integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
 
-react-is@^16.3.2, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6:
+react-is@^16.3.2, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -9958,6 +10019,35 @@ react-refresh@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
+
+react-router-dom@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.3.0.tgz#da1bfb535a0e89a712a93b97dd76f47ad1f32363"
+  integrity sha512-ObVBLjUZsphUUMVycibxgMdh5jJ1e3o+KpAZBVeHcNQZ4W+uUGGWsokurzlF4YOldQYRQL4y6yFRWM4m3svmuQ==
+  dependencies:
+    "@babel/runtime" "^7.12.13"
+    history "^4.9.0"
+    loose-envify "^1.3.1"
+    prop-types "^15.6.2"
+    react-router "5.2.1"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+
+react-router@5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.2.1.tgz#4d2e4e9d5ae9425091845b8dbc6d9d276239774d"
+  integrity sha512-lIboRiOtDLFdg1VTemMwud9vRVuOCZmUIT/7lUoZiSpPODiiH1UQlfXy+vPLC/7IWdFYnhRwAyNqA/+I7wnvKQ==
+  dependencies:
+    "@babel/runtime" "^7.12.13"
+    history "^4.9.0"
+    hoist-non-react-statics "^3.1.0"
+    loose-envify "^1.3.1"
+    mini-create-react-context "^0.4.0"
+    path-to-regexp "^1.7.0"
+    prop-types "^15.6.2"
+    react-is "^16.6.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
 
 react-scripts@^4.0.3:
   version "4.0.3"
@@ -10334,6 +10424,11 @@ resolve-from@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
+
+resolve-pathname@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-3.0.0.tgz#99d02224d3cf263689becbb393bc560313025dcd"
+  integrity sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==
 
 resolve-url-loader@^3.1.2:
   version "3.1.4"
@@ -11509,6 +11604,16 @@ timsort@^0.3.0:
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
 
+tiny-invariant@^1.0.2:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
+  integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
+
+tiny-warning@^1.0.0, tiny-warning@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
+  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
+
 tmpl@1.0.x:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.5.tgz#8683e0b902bb9c20c4f726e3c0b69f36518c07cc"
@@ -11992,6 +12097,11 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+value-equal@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-1.0.1.tgz#1e0b794c734c5c0cade179c437d356d931a34d6c"
+  integrity sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Pardon a large, unannounced PR. I figured it will be easier to write the code and present what I have in mind that explain : ).

I propose to add a dev page for kill team 21 data. 
Why? We now have that large collection of data. It's going to need some updates in formatting, it will need some custom components, etc. For the very least, we are going to need to see how the data looks rendered. Hence, let's add a page, and on that page allow to render any faction-specific footer as it would appear on the roster.
In order to do that, I:

1. Added a `name` field to all of the faction datas. It's useful in further processing of the data.
2. Removed `tacOps: null` from all related factions. I figure we are going to have more fields that are specific to a single faction. Better figure out how to deal with them
3. Added a `data` array to store all of the faction data objects. Made `getFactionSpecificData` be implemented based on it.
4. Implemented a `FactionSpecificData` component. It's all of the components used to render faction specific data, I just moved it and gave it a name.
5. Implemented a `DataDevPage` component. `FactionSpecificData` is used in both `DataDevPage` and `Roster`
6. Added `react-router-dev` and expose `DataDevPage` component on a url with it. Old logic stays untouched on the root url.
7. Tried my best to lint the files I'm adding.

Let me know if this is something you think would be beneficial. I am also happy to answer any questions.