### PR TITLE
Chalnath wahapedia links

### DIFF
--- a/src/components/KillTeam2021/AbilityList.tsx
+++ b/src/components/KillTeam2021/AbilityList.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Ability } from '../../types/Ability'
 import { Card } from 'react-bootstrap'
 import _ from 'lodash'
-import { HighlightedText } from './HighlightedText'
+import { CompileDescription } from './CompileDescription'
 
 interface Props {
   abilities: Ability[]
@@ -18,7 +18,7 @@ function AbilityList (props: Props): JSX.Element {
         {_.sortBy(props.abilities, ['name']).map((x: Ability) => (
           <p key={x.id}>
             <strong>{x.name}: </strong>
-            <HighlightedText>{x.description}</HighlightedText>
+            <CompileDescription>{x.description}</CompileDescription>
           </p>
         ))}
       </Card.Body>

--- a/src/components/KillTeam2021/FactionSpecificData/FactionSpecificData.tsx
+++ b/src/components/KillTeam2021/FactionSpecificData/FactionSpecificData.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react'
 import { VeteranGuardsmen } from './VeteranGuardsmen'
 import { Pathfinder } from './Pathfinder'
 import { Default } from './Default'
+import { Novitiate } from './Novitiate'
 
 interface Props {
   faction: string
@@ -9,10 +10,14 @@ interface Props {
 }
 
 export const FactionSpecificData: FC<Props> = (props) => {
+  console.log(props.faction)
   switch (props.faction) {
     case 'Veteran Guardsmen':
       return <VeteranGuardsmen fireteams={props.fireteams} />
+    case 'Novitiate':
+      return <Novitiate fireteams={props.fireteams} />
     case 'Pathfinder':
+      console.log('PATHFINDER SWITCH')
       return <Pathfinder fireteams={props.fireteams} />
     default:
       return <Default faction={props.faction} fireteams={props.fireteams} />

--- a/src/components/KillTeam2021/FactionSpecificData/FactionSpecificData.tsx
+++ b/src/components/KillTeam2021/FactionSpecificData/FactionSpecificData.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react'
 import { VeteranGuardsmen } from './VeteranGuardsmen'
+import { Pathfinder } from './Pathfinder'
 import { Default } from './Default'
 
 interface Props {
@@ -11,6 +12,8 @@ export const FactionSpecificData: FC<Props> = (props) => {
   switch (props.faction) {
     case 'Veteran Guardsmen':
       return <VeteranGuardsmen fireteams={props.fireteams} />
+    case 'Pathfinder':
+      return <Pathfinder fireteams={props.fireteams} />
     default:
       return <Default faction={props.faction} fireteams={props.fireteams} />
   }

--- a/src/components/KillTeam2021/FactionSpecificData/Novitiate.tsx
+++ b/src/components/KillTeam2021/FactionSpecificData/Novitiate.tsx
@@ -63,7 +63,7 @@ export const Novitiate: FC<Props> = (props) => {
         <Card style={{ width: '100%', marginRight: '5px' }}>
           <Card.Header style={{ ...headingStyle }} as='h2'>{factionSpecificData.actsOfFaith.name}</Card.Header>
           <Card.Body>
-            <CompileDescription>{factionSpecificData.actsOfFaith.description}</CompileDescription>
+            <a href={factionSpecificData.actsOfFaith.wahapediaUrl} target='_blank' rel='noreferrer'>Full Rules</a>
             <Col>
               {factionSpecificData.actsOfFaith.acts.map(x => (
                 <Card key={x.name} border='info' bg='light'>

--- a/src/components/KillTeam2021/FactionSpecificData/Novitiate.tsx
+++ b/src/components/KillTeam2021/FactionSpecificData/Novitiate.tsx
@@ -6,13 +6,12 @@ import getFactionSpecificData from './../data'
 import { Card, Col } from 'react-bootstrap'
 import { CompileDescription } from '../CompileDescription'
 import { ArchetypePanel } from './components/ArchetypePanel'
-import AbilityList from '../AbilityList'
 
 interface Props {
   fireteams: string[]
 }
 
-export const Pathfinder: FC<Props> = (props) => {
+export const Novitiate: FC<Props> = (props) => {
   const headingStyle = {
     background: '#FF6F2D',
     color: 'black',
@@ -20,10 +19,9 @@ export const Pathfinder: FC<Props> = (props) => {
     width: '100%',
     display: 'flex'
   }
+  const factionSpecificData = getFactionSpecificData('Novitiate')
 
-  const factionSpecificData = getFactionSpecificData('Pathfinder')
-
-  if (factionSpecificData === undefined || factionSpecificData.name !== 'Pathfinder') {
+  if (factionSpecificData === undefined || factionSpecificData.name !== 'Novitiate') {
     return <></>
   }
 
@@ -63,25 +61,14 @@ export const Pathfinder: FC<Props> = (props) => {
       </div>
       <div style={{ display: 'flex', justifyContent: 'space-between', flexDirection: 'row' }}>
         <Card style={{ width: '100%', marginRight: '5px' }}>
-          <Card.Header style={{ ...headingStyle }} as='h2'>{factionSpecificData.markerLights.name}</Card.Header>
+          <Card.Header style={{ ...headingStyle }} as='h2'>{factionSpecificData.actsOfFaith.name}</Card.Header>
           <Card.Body>
-            <CompileDescription>{factionSpecificData.markerLights.description}</CompileDescription>
-            <AbilityList abilities={factionSpecificData.markerLights.abilities} />
-            <CompileDescription>{factionSpecificData.markerLights.description2}</CompileDescription>
-          </Card.Body>
-        </Card>
-      </div>
-      <div style={{ display: 'flex', justifyContent: 'space-between', flexDirection: 'row' }}>
-        <Card style={{ width: '100%', marginRight: '5px' }}>
-          <Card.Header style={{ ...headingStyle }} as='h2'>{factionSpecificData.artOfWar.name}</Card.Header>
-          <Card.Body>
-            <CompileDescription>{factionSpecificData.artOfWar.description}</CompileDescription>
-
+            <CompileDescription>{factionSpecificData.actsOfFaith.description}</CompileDescription>
             <Col>
-              {factionSpecificData.artOfWar.options.map(x => (
+              {factionSpecificData.actsOfFaith.acts.map(x => (
                 <Card key={x.name} border='info' bg='light'>
                   <Card.Header style={{ background: '#17a2b8', color: 'white', display: 'flex', justifyContent: 'space-between' }} as='h4'>
-                    <span>{x.name}</span>
+                    <span>{x.name} - {x.cost}</span>
                   </Card.Header>
                   <Card.Body>
                     <CompileDescription>{x.description}</CompileDescription>

--- a/src/components/KillTeam2021/FactionSpecificData/Pathfinder.tsx
+++ b/src/components/KillTeam2021/FactionSpecificData/Pathfinder.tsx
@@ -6,6 +6,7 @@ import getFactionSpecificData from './../data'
 import { Card, Col } from 'react-bootstrap'
 import { CompileDescription } from '../CompileDescription'
 import { ArchetypePanel } from './components/ArchetypePanel'
+import AbilityList from '../AbilityList'
 
 interface Props {
   fireteams: string[]
@@ -62,6 +63,17 @@ export const Pathfinder: FC<Props> = (props) => {
       </div>
       <div style={{ display: 'flex', justifyContent: 'space-between', flexDirection: 'row' }}>
         <Card style={{ width: '100%', marginRight: '5px' }}>
+          <Card.Header style={{ ...headingStyle }} as='h2'>{factionSpecificData.markerLights.name}</Card.Header>
+          <Card.Body>
+            <CompileDescription>{factionSpecificData.markerLights.description}</CompileDescription>
+            <AbilityList abilities={factionSpecificData.markerLights.abilities} />
+            <CompileDescription>{factionSpecificData.markerLights.description2}</CompileDescription>
+          </Card.Body>
+        </Card>
+
+      </div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', flexDirection: 'row' }}>
+        <Card style={{ width: '100%', marginRight: '5px' }}>
           <Card.Header style={{ ...headingStyle }} as='h2'>{factionSpecificData.artOfWar.name}</Card.Header>
           <Card.Body>
             <CompileDescription>{factionSpecificData.artOfWar.description}</CompileDescription>
@@ -80,7 +92,6 @@ export const Pathfinder: FC<Props> = (props) => {
             </Col>
           </Card.Body>
         </Card>
-
       </div>
     </>
   )

--- a/src/components/KillTeam2021/FactionSpecificData/Pathfinder.tsx
+++ b/src/components/KillTeam2021/FactionSpecificData/Pathfinder.tsx
@@ -1,0 +1,87 @@
+import React, { FC } from 'react'
+import { Archetype } from '../../../types/KillTeam2021'
+import { PloysColumn } from './components/PloysColumn'
+import { TacOpsList } from './components/TacOpsList'
+import getFactionSpecificData from './../data'
+import { Card, Col } from 'react-bootstrap'
+import { CompileDescription } from '../CompileDescription'
+import { ArchetypePanel } from './components/ArchetypePanel'
+
+interface Props {
+  fireteams: string[]
+}
+
+export const Pathfinder: FC<Props> = (props) => {
+  const headingStyle = {
+    background: '#FF6F2D',
+    color: 'black',
+    padding: '10px',
+    width: '100%',
+    display: 'flex'
+  }
+
+  const factionSpecificData = getFactionSpecificData('Pathfinder')
+
+  if (factionSpecificData === undefined || factionSpecificData.name !== 'Pathfinder') {
+    return <></>
+  }
+
+  const archetypes: Archetype[] = props.fireteams
+    .flatMap(fireteam => factionSpecificData.archetypes.fireteams[fireteam] as unknown as Archetype)
+    .filter(Boolean)
+    .filter((item, index, self) => self.indexOf(item) === index)
+
+  const archetypeRules = factionSpecificData?.archetypes.rules ?? null
+
+  return (
+    <>
+      <div style={{ display: 'flex', justifyContent: 'space-between', flexDirection: 'row' }}>
+        <Card style={{ width: '100%', marginRight: '5px' }}>
+          <Card.Header style={{ ...headingStyle }} as='h2'>Strategic Ploys</Card.Header>
+          <Card.Body>
+            <PloysColumn ploys={factionSpecificData.strategicPloys} />
+          </Card.Body>
+        </Card>
+        <Card style={{ width: '100%', marginLeft: '5px' }}>
+          <Card.Header style={{ ...headingStyle }} as='h2'>Tactical Ploys</Card.Header>
+          <Card.Body>
+            <PloysColumn ploys={factionSpecificData.tacticalPloys} />
+          </Card.Body>
+        </Card>
+      </div>
+      <div>
+        <Card>
+          <Card.Header style={{ ...headingStyle }} as='h2'>Tac Ops</Card.Header>
+          <Card.Body>
+            <Card.Title>
+              <ArchetypePanel archetypes={archetypes} archetypeRules={archetypeRules} />
+            </Card.Title>
+            <TacOpsList tacOps={factionSpecificData?.tacOps} />
+          </Card.Body>
+        </Card>
+      </div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', flexDirection: 'row' }}>
+        <Card style={{ width: '100%', marginRight: '5px' }}>
+          <Card.Header style={{ ...headingStyle }} as='h2'>{factionSpecificData.artOfWar.name}</Card.Header>
+          <Card.Body>
+            <CompileDescription>{factionSpecificData.artOfWar.description}</CompileDescription>
+
+            <Col>
+              {factionSpecificData.artOfWar.options.map(x => (
+                <Card key={x.name} border='info' bg='light'>
+                  <Card.Header style={{ background: '#17a2b8', color: 'white', display: 'flex', justifyContent: 'space-between' }} as='h4'>
+                    <span>{x.name}</span>
+                  </Card.Header>
+                  <Card.Body>
+                    <CompileDescription>{x.description}</CompileDescription>
+                  </Card.Body>
+                </Card>
+              ))}
+            </Col>
+          </Card.Body>
+        </Card>
+
+      </div>
+    </>
+  )
+}

--- a/src/components/KillTeam2021/FactionSpecificData/Pathfinder.tsx
+++ b/src/components/KillTeam2021/FactionSpecificData/Pathfinder.tsx
@@ -65,9 +65,9 @@ export const Pathfinder: FC<Props> = (props) => {
         <Card style={{ width: '100%', marginRight: '5px' }}>
           <Card.Header style={{ ...headingStyle }} as='h2'>{factionSpecificData.markerLights.name}</Card.Header>
           <Card.Body>
-            <CompileDescription>{factionSpecificData.markerLights.description}</CompileDescription>
+            <a href={factionSpecificData.markerLights.wahapediaUrl} target='_blank' rel='noreferrer'>Full Rules</a>
             <AbilityList abilities={factionSpecificData.markerLights.abilities} />
-            <CompileDescription>{factionSpecificData.markerLights.description2}</CompileDescription>
+            <CompileDescription>{factionSpecificData.markerLights.benefitTable}</CompileDescription>
           </Card.Body>
         </Card>
       </div>
@@ -75,8 +75,7 @@ export const Pathfinder: FC<Props> = (props) => {
         <Card style={{ width: '100%', marginRight: '5px' }}>
           <Card.Header style={{ ...headingStyle }} as='h2'>{factionSpecificData.artOfWar.name}</Card.Header>
           <Card.Body>
-            <CompileDescription>{factionSpecificData.artOfWar.description}</CompileDescription>
-
+            <a href={factionSpecificData.artOfWar.wahapediaUrl} target='_blank' rel='noreferrer'>Full Rules</a>
             <Col>
               {factionSpecificData.artOfWar.options.map(x => (
                 <Card key={x.name} border='info' bg='light'>

--- a/src/components/KillTeam2021/data/index.ts
+++ b/src/components/KillTeam2021/data/index.ts
@@ -20,6 +20,7 @@ import traitorSpaceMarine from './traitorSpaceMarine'
 import troupe from './troupe'
 import veteranGuardsmen from './veteranGuardsmen'
 import warpCoven from './warpCoven'
+import pathfinder from './pathfinder'
 
 const data = [
   broodCoven,
@@ -37,6 +38,7 @@ const data = [
   hunterClade,
   imperialGuard,
   kommando,
+  pathfinder,
   spaceMarine,
   talonsOfTheEmperor,
   thousandSons,

--- a/src/components/KillTeam2021/data/index.ts
+++ b/src/components/KillTeam2021/data/index.ts
@@ -12,6 +12,7 @@ import hiveFleet from './hiveFleet'
 import hunterCadre from './hunterCadre'
 import hunterClade from './hunterClade'
 import imperialGuard from './imperialGuard'
+import novitiate from './novitiate'
 import kommando from './kommando'
 import spaceMarine from './spaceMarine'
 import talonsOfTheEmperor from './talonsOfTheEmperor'
@@ -38,6 +39,7 @@ const data = [
   hunterClade,
   imperialGuard,
   kommando,
+  novitiate,
   pathfinder,
   spaceMarine,
   talonsOfTheEmperor,

--- a/src/components/KillTeam2021/data/kommando.ts
+++ b/src/components/KillTeam2021/data/kommando.ts
@@ -70,7 +70,7 @@ const tacOps: TacOp[] = [
   - At the end of the second Turning Point, if friendly operatives control more objective markers than enemy operatives control, you score 1 VP`
   }, {
     id: 3,
-    name: 'Get stick in!',
+    name: 'Get stuck in!',
     description: `You can reveal this Tac Op in the Reveal Tac Ops step of any turning Point
   - At the end of any turning Point (excluding the fourth), if three or more friendly operatives are within ⬟ of your opponents drop zone, you score 1 VP.
   - If you achieve the first condition at the end of any subsequent Turning Points (excluding the fourth), you score 1 VP.`

--- a/src/components/KillTeam2021/data/novitiate.ts
+++ b/src/components/KillTeam2021/data/novitiate.ts
@@ -57,7 +57,7 @@ const tacticalPloys: Ploy[] = [
     cost: 1,
     description: `Use this Tactical Ploy after rolling your attack dice for a shooting attack made by a friendly **NOVITIATE CONDEMNOR** operative. You can re-roll any 
                   or all of your attack dice for that shooting attack.`
-  },
+  }
 ]
 
 const tacOps: TacOp[] = [

--- a/src/components/KillTeam2021/data/novitiate.ts
+++ b/src/components/KillTeam2021/data/novitiate.ts
@@ -1,0 +1,93 @@
+import { Archetype, FireteamArchetypes, Ploy, TacOp } from '../../../types/KillTeam2021'
+
+const archetypes: FireteamArchetypes = {
+  fireteams: {
+    'Novitiate Kill Team': [Archetype.RECON]
+  }
+}
+
+const strategicPloys: Ploy[] = [
+  {
+    name: 'Eyes of the Emperor',
+    cost: 1,
+    description: `Until the end of the Turning Point, remove the Range special rule from autopistols, bolt pistols and plasma pistols that friendly NOVITIATE💀 operatives
+                  are equipped with.`
+  },
+  {
+    name: 'Sanctified Rounds',
+    cost: 1,
+    description: 'Until the end of the Turning Point, add 1 to both Damage characteristics of autoguns and autopistols that friendly NOVITIATE💀 operatives are equipped with.'
+  },
+  {
+    name: 'Aegis of the Emperor',
+    cost: 1,
+    description: `Until the end of the Turning Point, each time an enemy operative within ⬟ of a friendly NOVITIATE💀 operative performs a psychic action, that enemy 
+                  operative suffers 1 mortal wound.`
+  },
+  {
+    name: 'Defenders of the Faith',
+    cost: 1,
+    description: `At the start of the Firefight phase, one friendly NOVITIATE💀 operative that is within ⬤ of the centre of each objective marker can:
+    
+- Perform a free **Shoot** action if it has an Engage order.
+- Perform a free **Fight** action if it has an Engage order.`
+  }
+]
+
+const tacticalPloys: Ploy[] = [
+  {
+    name: 'Glorious Martyrdom',
+    cost: 1,
+    description: `Use this Tactical Ploy when a friendly NOVITIATE💀 operative is incapacitated. Each enemy operative within ⬤ of and Visible to that operative suffer 1 
+                  mortal wound, and you gain D3 Faith points.`
+  },
+  {
+    name: 'Burning Wrath',
+    cost: 1,
+    description: `Select one friendly **NOVITIATE PURGATUS** operative. Until the end of the turning point, that operative's Ministorum flamer has the following profile:
+    
+|Name|A|BS|D|
+|-|-|-|-|
+|Ministorum flamer|5|2+|3/4|
+|Special Rules|
+|Inferno 2, Rng ⬟, Torrent ⬤|`
+  },
+  {
+    name: 'Righteous Condemnation',
+    cost: 1,
+    description: `Use this Tactical Ploy after rolling your attack dice for a shooting attack made by a friendly **NOVITIATE CONDEMNOR** operative. You can re-roll any 
+                  or all of your attack dice for that shooting attack.`
+  },
+]
+
+const tacOps: TacOp[] = [
+  {
+    id: 1,
+    name: 'Purge With Flame',
+    description: `You can reveal this Tac Op in the Target Reveal Step of any Turning Point.  
+  - If two or more enemy operatives are incapacitated by attacks made by weapons with the Inferno x special rule, you score 1VP.
+  - If an enemy **LEADER** operative is incapacitated by an attack made by a weapon with the Inferno x critical hit rule, you score 1VP`
+  }, {
+    id: 2,
+    name: 'Reconsecrate Ground',
+    description: `Reveal this Tac Op in the Target Reveal step of the first Turning Point. Select one objective marker that is not within ⬟ of your drop zone:
+  - At the end of any Turning Point, if friendly operatives control that objective marker, you score 1VP.
+  - At the end of the battle, if friendly operatives control that objective marker, you score 1VP.`
+  }, {
+    id: 3,
+    name: 'Glory to the Martyrs',
+    description: `Reveal this Tac Op when a friendly operative is incapacitated while within ⬤ of the centre of an objective marker.
+  - If another friendly operative is incapacitated while within ⬤ of the centre of that objective marker, you score 1VP.
+  - If you achieve the first condition in any subsequent Turning Points, you score 1VP.`
+  }
+]
+
+const data = {
+  name: 'Notiviate' as const,
+  strategicPloys,
+  tacticalPloys,
+  archetypes,
+  tacOps
+}
+
+export default data

--- a/src/components/KillTeam2021/data/novitiate.ts
+++ b/src/components/KillTeam2021/data/novitiate.ts
@@ -84,6 +84,7 @@ const tacOps: TacOp[] = [
 
 const actsOfFaith = {
   name: 'Acts of Faith',
+  wahapediaUrl: 'https://wahapedia.ru/kill-team2/kill-teams/novitiate/#Acts-of-Faith',
   description: `Keep a pool of Faith points. At the start of each Turning Point, if there are any friendly NOVITIATE💀 operatives in the kill zone, you gain 3 Faith points. 
 In addition, you gain one Faith point at the end of an activation, if any of the following apply:
 - During that activation, a friendly NOVITIATE💀 operative with the Combat specialism incapacitated an enemy operative in a combat.

--- a/src/components/KillTeam2021/data/novitiate.ts
+++ b/src/components/KillTeam2021/data/novitiate.ts
@@ -2,7 +2,7 @@ import { Archetype, FireteamArchetypes, Ploy, TacOp } from '../../../types/KillT
 
 const archetypes: FireteamArchetypes = {
   fireteams: {
-    'Novitiate Kill Team': [Archetype.RECON]
+    'Novitiate Kill Team': [Archetype.SECURITY, Archetype.RECON]
   }
 }
 
@@ -82,12 +82,82 @@ const tacOps: TacOp[] = [
   }
 ]
 
+const actsOfFaith = {
+  name: 'Acts of Faith',
+  description: `Keep a pool of Faith points. At the start of each Turning Point, if there are any friendly NOVITIATE💀 operatives in the kill zone, you gain 3 Faith points. 
+In addition, you gain one Faith point at the end of an activation, if any of the following apply:
+- During that activation, a friendly NOVITIATE💀 operative with the Combat specialism incapacitated an enemy operative in a combat.
+- During that activation, a friendly NOVITIATE💀 operative with the Marksman specialism incapacitated an enemy operative with a shooting attack.
+- During that activation, a friendly NOVITIATE💀 operative with the Staunch specialism performed a mission action.
+- A friendly NOVITIATE💀 operative with the Scout specialism was activated and finished that activation within ⬟ of the enemy drop zone.
+
+Faith points can be subtracted so that friendly NOVITIATE💀 operatives can perform Acts of Faith listed below. Each Act of Faith will specify when it can be used, 
+its effect and how many Faith points you must subtract from your total to use it. If you cannot subtract the required Faith points from your total, you cannot use that Act of Faith.
+
+Unless otherwise specified, only one Act of Faith can be used during each activation (friendly or enemy). For example, a shooting attack is made against a friendly 
+NOVITIATE💀 operative. In the Roll Defence Dice step of that shooting attack, that operative's controlling player decides to subtract 2 Faith points to use Divine Shield to 
+retain one failed save as a successful normal save. No other Acts of Faith can then be performed during that activation (other than Faithful Blessing).
+`,
+  acts: [
+    {
+      name: 'Faithful Blessing',
+      description: `When a friendly NOVITIATE💀 operative fights in combat or makes a shooting attack, in the Roll Attack Dice or Roll Defence Dice 
+                    step of that combat or shooting attack, re-roll one of your attack or defence dice. This Act of Faith can be used more than once in each activation, 
+                    and can be used with other Acts of Faith.`,
+      cost: '1 Faith Point'
+    },
+    {
+      name: 'Guiding Light',
+      description: `When a friendly NOVITIATE💀 operative fights in combat or makes a shooting attack, in the Roll Attack Dice step of that combat 
+                    or shooting attack, retain one of your failed hits as a successful normal hit.`,
+      cost: '2 Faith Points'
+    },
+    {
+      name: 'Vengeful Strike',
+      description: `When a friendly NOVITIATE💀 operative fights in combat or makes a shooting attack, in the Roll Attack Dice step of that combat or 
+                    shooting attack, retain one of your successful normal hits as a critical hit instead.`,
+      cost: '3 Faith Points'
+    },
+    {
+      name: 'Divine Shield',
+      description: `When a shooting attack is made against a friendly NOVITIATE💀 operative, in the Roll Defence Dice step of that shooting attack, 
+                    retain one of your failed saves as a successful normal save.`,
+      cost: '2 Faith Points'
+    },
+    {
+      name: 'Armour of Contempt',
+      description: `When a shooting attack is made against a friendly NOVITIATE💀 operative, in the Roll Defence Dice step of that shooting attack,
+                    retain one of your successful normal saves as a critical save instead.`,
+      cost: '2 Faith Points'
+    },
+    {
+      name: 'Emperor\'s Protection',
+      description: `When a friendly NOVITIATE💀 operative suffers a mortal wound, ignore that mortal wound. This Act of Faith can be used more than 
+                    once in each activation.`,
+      cost: '1 Faith Point'
+    },
+    {
+      name: 'Blessed Rejuvenation',
+      description: `When a friendly NOVITIATE💀 operative is activated, it regains D3 lost wounds. This Act of Faith can be used a maximum of two
+                    times in each activation.`,
+      cost: '2 Faith Points'
+    },
+    {
+      name: 'Blinding Aura',
+      description: `When an enemy operative performs a shooting attack, select one friendly NOVITIATE💀 operative. Until the end of that activation, while 
+                    that friendly operative is more than ⬤ from that enemy operative, that friendly operative is treated as being in Cover.`,
+      cost: '2 Faith Points'
+    }
+  ]
+}
+
 const data = {
-  name: 'Notiviate' as const,
+  name: 'Novitiate' as const,
   strategicPloys,
   tacticalPloys,
   archetypes,
-  tacOps
+  tacOps,
+  actsOfFaith
 }
 
 export default data

--- a/src/components/KillTeam2021/data/pathfinder.ts
+++ b/src/components/KillTeam2021/data/pathfinder.ts
@@ -63,7 +63,7 @@ const tacOps: TacOp[] = [
     description: `You can reveal this Tac Op in the Target Reveal Step of any Turning Point.  
   - At the end of any Turning Point, if at least half of the enemy operatives in the killzone (rounding down and a minimum of 3 enemy operatives) have one or more markerlight
     tokens, you score 1VP.
-  - If you achieve the first condition in any subsequent Turning Points, you score 1VP.`,
+  - If you achieve the first condition in any subsequent Turning Points, you score 1VP.`
   }, {
     id: 2,
     name: 'Patient Hunter',
@@ -81,6 +81,100 @@ const tacOps: TacOp[] = [
   - If you achieve the first condition in any subsequent Turning Points, you score IVP.`
   }
 ]
+
+const artOfWar = {
+  name: 'Art of War',
+  description: `Pathfinder Shas'uis are accomplished leaders. They have spent years studying the philosophies of T'au warfare, and have years of experience in implementing them.
+                When a SHAS'UI operative uses its Art of War ability, select one Art of War below to be in effect until the end of the Turning Point.`,
+  options: [{
+    name: `Mont'ka`,
+    description: `Each time a friendly PATHFINDER operative is activated, if it has an Engage order for that activation, it can perform a free Dash action during that activation.`
+  }, {
+    name: `Kauyon`,
+    description: `Each time a shooting is made against a friendly PATHFINDER operative before rolling your defence dice, if it is in Cover additional dice can be retained as 
+                  a successful normal save as a result of Cover.`
+  }]
+}
+
+const markerLights = {
+  name: ``
+}
+
+/*
+MARKERLIGHTS
+A markerlight is a device that projects a beam onto a target. Once an enemy has been 'painted' by such a beam, a torrent of targeting data is fed into the cadre tactical network, relaying ranges, triangulating optimum firing trajectories and superimposing aiming vectors to other T'au warriors, allowing them to engage the target with unerring accuracy.
+MARKERLIGHT
+1AP
+Select one enemy operative Visible to this operative. That enemy operative gains 1 Markerlight token. An operative cannot perform this action if it is within Engagement Range of an enemy operative. If an operative would perform this action and a Shoot action in the same activation, only the target of that Shoot action's shooting attack can be selected for this action.
+Operatives gain Markerlight tokens as specified by the Markerlight action above. In the Ready Operatives step of each Initiative phase, remove one Markerlight token that each operatives has.
+Each time a friendly PATHFINDERS operative makes a shooting attack, it gains a number of cumulative benefits for that shooting attack depending on how many Markerlight tokens the target operative has. Operatives gain no markerlight benefits for shooting attacks made with EMP and fusion grenades.
+Markerlight Tokens
+1+
+Benefit
+In the Roll Attack Dice step of that
+shooting attack, you can re-roll one of your attack dice.
+For that shooting attack, the active operative's ranged weapons gain the No Cover special rule.
+For that shooting attack, improve the Ballistic Skill characteristic of ranged weapons the active operative is equipped with by 1.
+In the Select Valid Target step of that shooting attack, the enemy operative is not Obscured.
+In the Select Valid Target step of that shooting attack, the enemy operative is treated as if it has an Engage order.
+2+
+3+
+4+
+ART OF WAR
+Pathfinder Shas'uis are accomplished leaders. They have spent years studying the philosophies of T'au warfare, and have years of experience in implementing them.
+When a SHAS'UI operative uses its Art of War ability, select one Art of War below to be in effect until the end of the Turning Point.
+Mont'ka
+Each time a friendly PATHFINDER operative is activated, if it has an Engage order for that activation, it can perform a free Dash action during that activation.
+Kauyon
+Each time a shooting is made against a friendly PATHFINDER operative barore rolling your defence dice, if it is in Cover additional dice can be retained as a successful normal save as a result of Cover.
+56
+but on
+PATHFINDERS
+ACTIONS
+KE COVE
+the end of th
+d's made aga
+DRON
+acteristic b
+DED
+end of the Tu
+DER operativ
+Dice step of
+her friendly PA
+perative), you ca
+TERMINED TA
+SHAS UI opera
+tilar ability in the p
+Poy Until the E
+MHFINDER opera
+SMAS UN operativ
+ed for your kill L
+ng in effect for this
+otka it can only F
+of and Visible to
+is declared. You
+5+
+Copy text
+MARKERLIGHTS
+A markerlight is a device that projects a beam onto a target. Once an enemy has been 'painted' by such a beam, a torrent of targeting data is fed into the cadre tactical network, relaying ranges, triangulating optimum firing trajectories and superimposing aiming vectors to other T'au warriors, allowing them to engage the target with unerring accuracy.
+MARKERLIGHT
+1AP
+Select one enemy operative Visible to this operative. That enemy operative gains 1 Markerlight token. An operative cannot perform this action if it is within Engagement Range of an enemy operative. If an operative would perform this action and a Shoot action in the same activation, only the target of that Shoot action's shooting attack can be selected for this action.
+Operatives gain Markerlight tokens as specified by the Markerlight action above. In the Ready Operatives step of each Initiative phase, remove one Markerlight token that each operatives has.
+Each time a friendly PATHFINDERS operative makes a shooting attack, it gains a number of cumulative benefits for that shooting attack depending on how many Markerlight tokens the target operative has. Operatives gain no markerlight benefits for shooting attacks made with EMP and fusion grenades.
+Markerlight Tokens
+1+
+Benefit
+In the Roll Attack Dice step of that
+shooting attack, you can re-roll one of your attack dice.
+For that shooting attack, the active operative's ranged weapons gain the No Cover special rule.
+For that shooting attack, improve the Ballistic Skill characteristic of ranged weapons the active operative is equipped with by 1.
+In the Select Valid Target step of that shooting attack, the enemy operative is not Obscured.
+In the Select Valid Target step of that shooting attack, the enemy operative is treated as if it has an Engage order.
+2+
+3+
+4+
+ */
 
 const data = {
   name: 'Pathfinder' as const,

--- a/src/components/KillTeam2021/data/pathfinder.ts
+++ b/src/components/KillTeam2021/data/pathfinder.ts
@@ -97,84 +97,32 @@ const artOfWar = {
 }
 
 const markerLights = {
-  name: ''
-}
+  name: 'Markerlights',
+  description: `A markerlight is a device that projects a beam onto a target. Once an enemy has been 'painted' by such a beam, a torrent of targeting data is fed into the 
+                cadre tactical network, relaying ranges, triangulating optimum firing trajectories and superimposing aiming vectors to other T'au warriors, allowing them 
+                to engage the target with unerring accuracy.`,
+  abilities: [{
+    id: '1',
+    name: 'Markerlight (1AP)',
+    description: `Select one enemy operative Visible to this operative. That enemy operative gains 1 Markerlight token. An operative cannot perform this action if it 
+                is within Engagement Range of an enemy operative. If an operative would perform this action and a **Shoot** action in the same activation, only the target 
+                of that **Shoot** action's shooting attack can be selected for this action.`
+  }],
+  description2:
+`Operatives gain Markerlight tokens as specified by the Markerlight action above. In the Ready Operatives step of each Initiative phase, remove one 
+Markerlight token that each operatives has.
+                  
+Each time a friendly PATHFINDER💀 operative makes a shooting attack, it gains a number of cumulative benefits for that shooting attack depending on how 
+many Markerlight tokens the target operative has. Operatives gain no markerlight benefits for shooting attacks made with EMP and fusion grenades.
 
-/*
-MARKERLIGHTS
-A markerlight is a device that projects a beam onto a target. Once an enemy has been 'painted' by such a beam, a torrent of targeting data is fed into the cadre tactical network, relaying ranges, triangulating optimum firing trajectories and superimposing aiming vectors to other T'au warriors, allowing them to engage the target with unerring accuracy.
-MARKERLIGHT
-1AP
-Select one enemy operative Visible to this operative. That enemy operative gains 1 Markerlight token. An operative cannot perform this action if it is within Engagement Range of an enemy operative. If an operative would perform this action and a Shoot action in the same activation, only the target of that Shoot action's shooting attack can be selected for this action.
-Operatives gain Markerlight tokens as specified by the Markerlight action above. In the Ready Operatives step of each Initiative phase, remove one Markerlight token that each operatives has.
-Each time a friendly PATHFINDERS operative makes a shooting attack, it gains a number of cumulative benefits for that shooting attack depending on how many Markerlight tokens the target operative has. Operatives gain no markerlight benefits for shooting attacks made with EMP and fusion grenades.
-Markerlight Tokens
-1+
-Benefit
-In the Roll Attack Dice step of that
-shooting attack, you can re-roll one of your attack dice.
-For that shooting attack, the active operative's ranged weapons gain the No Cover special rule.
-For that shooting attack, improve the Ballistic Skill characteristic of ranged weapons the active operative is equipped with by 1.
-In the Select Valid Target step of that shooting attack, the enemy operative is not Obscured.
-In the Select Valid Target step of that shooting attack, the enemy operative is treated as if it has an Engage order.
-2+
-3+
-4+
-ART OF WAR
-Pathfinder Shas'uis are accomplished leaders. They have spent years studying the philosophies of T'au warfare, and have years of experience in implementing them.
-When a SHAS'UI operative uses its Art of War ability, select one Art of War below to be in effect until the end of the Turning Point.
-Mont'ka
-Each time a friendly PATHFINDER operative is activated, if it has an Engage order for that activation, it can perform a free Dash action during that activation.
-Kauyon
-Each time a shooting is made against a friendly PATHFINDER operative barore rolling your defence dice, if it is in Cover additional dice can be retained as a successful normal save as a result of Cover.
-56
-but on
-PATHFINDERS
-ACTIONS
-KE COVE
-the end of th
-d's made aga
-DRON
-acteristic b
-DED
-end of the Tu
-DER operativ
-Dice step of
-her friendly PA
-perative), you ca
-TERMINED TA
-SHAS UI opera
-tilar ability in the p
-Poy Until the E
-MHFINDER opera
-SMAS UN operativ
-ed for your kill L
-ng in effect for this
-otka it can only F
-of and Visible to
-is declared. You
-5+
-Copy text
-MARKERLIGHTS
-A markerlight is a device that projects a beam onto a target. Once an enemy has been 'painted' by such a beam, a torrent of targeting data is fed into the cadre tactical network, relaying ranges, triangulating optimum firing trajectories and superimposing aiming vectors to other T'au warriors, allowing them to engage the target with unerring accuracy.
-MARKERLIGHT
-1AP
-Select one enemy operative Visible to this operative. That enemy operative gains 1 Markerlight token. An operative cannot perform this action if it is within Engagement Range of an enemy operative. If an operative would perform this action and a Shoot action in the same activation, only the target of that Shoot action's shooting attack can be selected for this action.
-Operatives gain Markerlight tokens as specified by the Markerlight action above. In the Ready Operatives step of each Initiative phase, remove one Markerlight token that each operatives has.
-Each time a friendly PATHFINDERS operative makes a shooting attack, it gains a number of cumulative benefits for that shooting attack depending on how many Markerlight tokens the target operative has. Operatives gain no markerlight benefits for shooting attacks made with EMP and fusion grenades.
-Markerlight Tokens
-1+
-Benefit
-In the Roll Attack Dice step of that
-shooting attack, you can re-roll one of your attack dice.
-For that shooting attack, the active operative's ranged weapons gain the No Cover special rule.
-For that shooting attack, improve the Ballistic Skill characteristic of ranged weapons the active operative is equipped with by 1.
-In the Select Valid Target step of that shooting attack, the enemy operative is not Obscured.
-In the Select Valid Target step of that shooting attack, the enemy operative is treated as if it has an Engage order.
-2+
-3+
-4+
- */
+|Markerlight Tokens|Benefit|
+|-|-|
+|1+|In the Roll Attack Dice step of that shooting attack, you can re-roll one of your attack dice.|
+|2+|For that shooting attack, the active operative's ranged weapons gain the No Cover special rule.|
+|3+|For that shooting attack, improve the Ballistic Skill characteristic of ranged weapons the active operative is equipped with by 1.|
+|4+|In the Select Valid Target step of that shooting attack, the enemy operative is not Obscured.|
+|5+|In the Select Valid Target step of that shooting attack, the enemy operative is treated as if it has an Engage order.|`
+}
 
 const data = {
   name: 'Pathfinder' as const,

--- a/src/components/KillTeam2021/data/pathfinder.ts
+++ b/src/components/KillTeam2021/data/pathfinder.ts
@@ -1,0 +1,93 @@
+import { Archetype, FireteamArchetypes, Ploy, TacOp } from '../../../types/KillTeam2021'
+
+const archetypes: FireteamArchetypes = {
+  fireteams: {
+    'Pathfinder Kill Team': [Archetype.RECON]
+  }
+}
+
+const strategicPloys: Ploy[] = [
+  {
+    name: 'Recon Sweep',
+    cost: 1,
+    description: `Friendly PATHFINDER💀 operatives that are wholly within ⬟ of any killzone edge can immediately perform a free **Dash** action, but only if they can finish
+          that move wholly within ⬟ of a killzone edge that is not your own killzone edge.`
+  }, {
+    name: 'Take Cover',
+    cost: 1,
+    description: `Until the end of the Turning Point, each time a shooting attack is made against a friendly PATHFINDER💀 operative (excluding a **DRONE** operative), 
+            if it is in Cover, improve its Save characteristic by 1 for that shooting attack.`
+  }, {
+    name: 'Bonded',
+    cost: 1,
+    description: `Until the end of the Turning Point, each time a friendly PATHFINDER💀 operative makes a shooting attack, in the Roll Attack Dice step of that shooting attack,
+                  if it is within ■ of another friendly PATHFINDER💀 operative (excluding a **DRONE** operative), you can re-roll one of your attack dice.`
+  }, {
+    name: 'Determined Tactician',
+    cost: 2,
+    description: `If a friendly **SHAS'UI** operative is in the killzone and it used its Art of War ability in the previous Turning Point, you can use this Strategic Ploy. Until 
+                  the end of the Turning Point, while a friendly PATHFINDER💀 operative is within ⬟ of and Visible to a friendly **SHAS'UI** operative, it treats the same Art of
+                  War that was in effect for your kill team in the previous Turning Point as being in effect for this Turning Point. Note that means for Mont'ka, it can only 
+                  perform that free **Dash** action if it is within ⬟ of and Visible to a friendly **SHAS'UI** operative when that action is declared. You can only use this 
+                  Strategic Ploy once.`
+  }
+]
+
+const tacticalPloys: Ploy[] = [
+  {
+    name: 'A Worthy Cause',
+    cost: 1,
+    description: `Use this tactical Ploy at the start of the Firefight phase. Select one friendly PATHFINDER💀 operative (excluding a **DRONE** operative) that is within ■ of any
+                  enemy or within ⬤ of the centre of an objective marker and activate it. Once that operative has completed its activation, the player who has the Initiative
+                  activates an operative as normal.`
+  }, {
+    name: 'Supporting Fire',
+    cost: 1,
+    description: `Use this Tactical Ploy in the Firefight phase, when a **Shoot** action is declared for a friendly PATHFINDER💀 operative. In the Select Valid Target step of that
+                  shooting attack, you must select an enemy operative that is within Engagement Range of a friendly operative and within ⬟ of the active operative, and that enemy
+                  operative cannot be in Cover as a result of friendly operatives' bases. Note, however, that in the Roll Defence Dice step of that shooting attack, the enemy
+                  operative can be in Cover as a result of friendly operatives' bases.`
+  }, {
+    name: 'Reposition',
+    cost: 1,
+    description: `Use this Tactical Ploy in the Firefight phase, when a friendly PATHFINDER💀 operative is activated. Until the end of its activation, that operative can perform
+                  **Dash** actions if it is within Engagement Range of an enemy operative and when performing that action, it can move within Engagement Range of enemy operatives,
+                  but cannot finish that move within Engagement Range of enemy operatives (if that is not possible, it cannot perform the action).`
+  }
+]
+
+const tacOps: TacOp[] = [
+  {
+    id: 1,
+    name: 'Mark Enemy Movements',
+    description: `You can reveal this Tac Op in the Target Reveal Step of any Turning Point.  
+  - At the end of any Turning Point, if at least half of the enemy operatives in the killzone (rounding down and a minimum of 3 enemy operatives) have one or more markerlight
+    tokens, you score 1VP.
+  - If you achieve the first condition in any subsequent Turning Points, you score 1VP.`,
+  }, {
+    id: 2,
+    name: 'Patient Hunter',
+    description: `You can reveal this Tac Op in the Target Reveal step of any Turning Point.
+  - At the end of any Turning Point, if you scored more victory points than your opponent for the mission objective during that Turning Point, and more 
+    than half of your operatives (rounding down) have a Conceal order, you score 1VP. 
+  - If you achieve the first condition in any subsequent Turning Points, you score 1VP.`
+  }, {
+    id: 3,
+    name: 'Killing Blow',
+    description: `You can reveal this Tac Op in the Target Reveal step of any Turning Point.
+  - At the end of any Turning Point, if the total Wounds characteristic of enemy operatives that were incapacitated during that Turning Point is greater than the total 
+  Wounds characteristic of friendly operatives that were incapacitated during that Turning Point, and more than half of your operatives (rounding down) have an Engage order, 
+  you score 1VP
+  - If you achieve the first condition in any subsequent Turning Points, you score IVP.`
+  }
+]
+
+const data = {
+  name: 'Pathfinder' as const,
+  strategicPloys,
+  tacticalPloys,
+  archetypes,
+  tacOps
+}
+
+export default data

--- a/src/components/KillTeam2021/data/pathfinder.ts
+++ b/src/components/KillTeam2021/data/pathfinder.ts
@@ -84,6 +84,7 @@ const tacOps: TacOp[] = [
 
 const artOfWar = {
   name: 'Art of War',
+  wahapediaUrl: 'https://wahapedia.ru/kill-team2/kill-teams/pathfinder/#Art-of-War',
   description: `Pathfinder Shas'uis are accomplished leaders. They have spent years studying the philosophies of T'au warfare, and have years of experience in implementing them.
                 When a **SHAS'UI** operative uses its Art of War ability, select one Art of War below to be in effect until the end of the Turning Point.`,
   options: [{
@@ -98,6 +99,7 @@ const artOfWar = {
 
 const markerLights = {
   name: 'Markerlights',
+  wahapediaUrl: 'https://wahapedia.ru/kill-team2/kill-teams/pathfinder/#Markerlights',
   description: `A markerlight is a device that projects a beam onto a target. Once an enemy has been 'painted' by such a beam, a torrent of targeting data is fed into the 
                 cadre tactical network, relaying ranges, triangulating optimum firing trajectories and superimposing aiming vectors to other T'au warriors, allowing them 
                 to engage the target with unerring accuracy.`,
@@ -113,8 +115,9 @@ const markerLights = {
 Markerlight token that each operatives has.
                   
 Each time a friendly PATHFINDER💀 operative makes a shooting attack, it gains a number of cumulative benefits for that shooting attack depending on how 
-many Markerlight tokens the target operative has. Operatives gain no markerlight benefits for shooting attacks made with EMP and fusion grenades.
+many Markerlight tokens the target operative has. Operatives gain no markerlight benefits for shooting attacks made with EMP and fusion grenades.`,
 
+  benefitTable: `
 |Markerlight Tokens|Benefit|
 |-|-|
 |1+|In the Roll Attack Dice step of that shooting attack, you can re-roll one of your attack dice.|

--- a/src/components/KillTeam2021/data/pathfinder.ts
+++ b/src/components/KillTeam2021/data/pathfinder.ts
@@ -85,7 +85,7 @@ const tacOps: TacOp[] = [
 const artOfWar = {
   name: 'Art of War',
   description: `Pathfinder Shas'uis are accomplished leaders. They have spent years studying the philosophies of T'au warfare, and have years of experience in implementing them.
-                When a SHAS'UI operative uses its Art of War ability, select one Art of War below to be in effect until the end of the Turning Point.`,
+                When a **SHAS'UI** operative uses its Art of War ability, select one Art of War below to be in effect until the end of the Turning Point.`,
   options: [{
     name: 'Mont\'ka',
     description: 'Each time a friendly PATHFINDER operative is activated, if it has an Engage order for that activation, it can perform a free Dash action during that activation.'

--- a/src/components/KillTeam2021/data/pathfinder.ts
+++ b/src/components/KillTeam2021/data/pathfinder.ts
@@ -87,17 +87,17 @@ const artOfWar = {
   description: `Pathfinder Shas'uis are accomplished leaders. They have spent years studying the philosophies of T'au warfare, and have years of experience in implementing them.
                 When a SHAS'UI operative uses its Art of War ability, select one Art of War below to be in effect until the end of the Turning Point.`,
   options: [{
-    name: `Mont'ka`,
-    description: `Each time a friendly PATHFINDER operative is activated, if it has an Engage order for that activation, it can perform a free Dash action during that activation.`
+    name: 'Mont\'ka',
+    description: 'Each time a friendly PATHFINDER operative is activated, if it has an Engage order for that activation, it can perform a free Dash action during that activation.'
   }, {
-    name: `Kauyon`,
+    name: 'Kauyon',
     description: `Each time a shooting is made against a friendly PATHFINDER operative before rolling your defence dice, if it is in Cover additional dice can be retained as 
                   a successful normal save as a result of Cover.`
   }]
 }
 
 const markerLights = {
-  name: ``
+  name: ''
 }
 
 /*
@@ -181,7 +181,9 @@ const data = {
   strategicPloys,
   tacticalPloys,
   archetypes,
-  tacOps
+  tacOps,
+  artOfWar,
+  markerLights
 }
 
 export default data


### PR DESCRIPTION
Alternative to https://github.com/Floppy/dataslate/pull/666, that replaces full descriptions of Novitiate and Pathfinder faction abilities with links to WahaPedia.