### PR TITLE
Group units with same equipment properly

### DIFF
--- a/src/parsers/KillTeam2021/BattlescribeParser.ts
+++ b/src/parsers/KillTeam2021/BattlescribeParser.ts
@@ -88,7 +88,7 @@ const parseAction = (action: Node, psychicDiscipline: string|null, psychicPowers
 const parseEquipment = (equipment: Node): Equipment => {
   const description = xpSelect(".//bs:characteristic[@name='Equipment']/text()", equipment, true)
   return {
-    id: xpSelect('string(@id)', equipment, true).toString(),
+    id: xpSelect('string(@entryId)', equipment, true).toString(),
     name: xpSelect('string(@name)', equipment, true).toString(),
     cost: parseInt(xpSelect('string(.//bs:cost/@value)', equipment, true).toString()),
     description: description?.toString()


### PR DESCRIPTION
Battlescribe gives a unique ID for the exact same equipment, which stopped units that look exactly the same from grouping together properly. Changed the parser to use ItemID instead which appears to be common for each type of equipment.