### PR TITLE
Show team rules as abilities

### DIFF
--- a/src/components/KillTeam2021/AbilityList.tsx
+++ b/src/components/KillTeam2021/AbilityList.tsx
@@ -19,9 +19,11 @@ function AbilityList (props: Props): JSX.Element {
         <Card.Body>
           {_.sortBy(props.abilities, ['name']).map((x: Ability) => (
             <p key={x.id}>
-              <strong>{x.name} {!(x.rule ?? false) && ':'} </strong>
+              <strong>{x.name}: </strong>
               {!(x.rule ?? false) &&
                 <CompileDescription>{x.description}</CompileDescription>}
+              {(x.rule ?? false) &&
+                <CompileDescription>See Rules Below</CompileDescription>}
             </p>
           ))}
         </Card.Body>

--- a/src/components/KillTeam2021/AbilityList.tsx
+++ b/src/components/KillTeam2021/AbilityList.tsx
@@ -19,8 +19,10 @@ function AbilityList (props: Props): JSX.Element {
         <Card.Body>
           {_.sortBy(props.abilities, ['name']).map((x: Ability) => (
             <p key={x.id}>
-              <strong>{x.name}: </strong>
-              <CompileDescription>{x.description}</CompileDescription>
+              <strong>{x.name} {!x.rule && ':' } </strong>
+                {!x.rule &&
+                    <CompileDescription>{x.description}</CompileDescription>
+                }
             </p>
           ))}
         </Card.Body>

--- a/src/components/KillTeam2021/AbilityList.tsx
+++ b/src/components/KillTeam2021/AbilityList.tsx
@@ -19,10 +19,9 @@ function AbilityList (props: Props): JSX.Element {
         <Card.Body>
           {_.sortBy(props.abilities, ['name']).map((x: Ability) => (
             <p key={x.id}>
-              <strong>{x.name} {!x.rule && ':' } </strong>
-                {!x.rule &&
-                    <CompileDescription>{x.description}</CompileDescription>
-                }
+              <strong>{x.name} {!(x.rule ?? false) && ':'} </strong>
+              {!(x.rule ?? false) &&
+                <CompileDescription>{x.description}</CompileDescription>}
             </p>
           ))}
         </Card.Body>

--- a/src/components/KillTeam2021/AbilityList.tsx
+++ b/src/components/KillTeam2021/AbilityList.tsx
@@ -23,7 +23,7 @@ function AbilityList (props: Props): JSX.Element {
               {!(x.rule ?? false) &&
                 <CompileDescription>{x.description}</CompileDescription>}
               {(x.rule ?? false) &&
-                <CompileDescription>See Rules Below</CompileDescription>}
+                <CompileDescription>See Rules Section Below</CompileDescription>}
             </p>
           ))}
         </Card.Body>

--- a/src/parsers/KillTeam2021/BattlescribeParser.ts
+++ b/src/parsers/KillTeam2021/BattlescribeParser.ts
@@ -33,7 +33,18 @@ const parseAbility = (ability: Node): Ability => {
     id: xpSelect('string(@id)', ability, true).toString(),
     name: xpSelect('string(@name)', ability, true).toString(),
     description: (xpSelect(".//bs:characteristic[@name='Ability']/text()", ability, true) ?? '-').toString(),
-    phases: []
+    phases: [],
+    rule: false
+  }
+}
+
+const parseOperativeRule = (rule: Node): Ability => {
+  return {
+    id: xpSelect('string(@id)', rule, true).toString(),
+    name: xpSelect('string(@name)', rule, true).toString(),
+    description: (xpSelect(".//bs:description/text()", rule, true) ?? '-').toString(),
+    phases: [],
+    rule: true
   }
 }
 
@@ -149,7 +160,8 @@ const parseOperative = (model: Element): Operative => {
   const psychicPowers = (xpSelect(".//bs:profile[@typeName='Psychic Power']/@name", model) as Node[]).map((x) => x.nodeValue).join(', ')
 
   const actions = (xpSelect(".//bs:profile[@typeName='Unique Actions']", model) as Node[]).map((x) => parseAction(x, psychicDiscipline, psychicPowers))
-  const abilities = (xpSelect(".//bs:profile[@typeName='Abilities']", model) as Node[]).map(parseAbility)
+  const abilities = (xpSelect(".//bs:profile[@typeName='Abilities']", model) as Node[]).map(parseAbility).concat(
+      (xpSelect("./bs:rules/bs:rule", model) as Node[]).map(parseOperativeRule))
 
   const boonOfTzeentch = xpSelect(".//bs:selection[./bs:profiles/bs:profile/@typeName='Boon of Tzeentch']", model, true) as Node
 

--- a/src/parsers/KillTeam2021/BattlescribeParser.ts
+++ b/src/parsers/KillTeam2021/BattlescribeParser.ts
@@ -42,7 +42,7 @@ const parseOperativeRule = (rule: Node): Ability => {
   return {
     id: xpSelect('string(@id)', rule, true).toString(),
     name: xpSelect('string(@name)', rule, true).toString(),
-    description: (xpSelect(".//bs:description/text()", rule, true) ?? '-').toString(),
+    description: (xpSelect('.//bs:description/text()', rule, true) ?? '-').toString(),
     phases: [],
     rule: true
   }
@@ -161,7 +161,7 @@ const parseOperative = (model: Element): Operative => {
 
   const actions = (xpSelect(".//bs:profile[@typeName='Unique Actions']", model) as Node[]).map((x) => parseAction(x, psychicDiscipline, psychicPowers))
   const abilities = (xpSelect(".//bs:profile[@typeName='Abilities']", model) as Node[]).map(parseAbility).concat(
-      (xpSelect("./bs:rules/bs:rule", model) as Node[]).map(parseOperativeRule))
+    (xpSelect('./bs:rules/bs:rule', model) as Node[]).map(parseOperativeRule))
 
   const boonOfTzeentch = xpSelect(".//bs:selection[./bs:profiles/bs:profile/@typeName='Boon of Tzeentch']", model, true) as Node
 

--- a/src/types/Ability.ts
+++ b/src/types/Ability.ts
@@ -3,4 +3,5 @@ export interface Ability {
   name: string
   description: string
   phases?: string[]
+  rule?: boolean
 }


### PR DESCRIPTION
Display ability names that apply to many models in a team, as per the official data cards in rule books.

https://github.com/Floppy/dataslate/issues/768